### PR TITLE
Docs: Emphasize "tsc agenda" label as preferred agenda intake in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 [![Join the chat at https://gitter.im/eslint/tsc-meetings](https://badges.gitter.im/eslint/tsc-meetings.svg)](https://gitter.im/eslint/tsc-meetings?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
-The ESLint TSC meets every other week to discuss issues related to the project. This repository contains the meeting notes along with other related information. 
+The ESLint TSC meets every other week to discuss issues related to the project. This repository contains the meeting notes along with other related information.
 
-Meeting are scheduled through issues on this repository. Agenda items may be added by leaving a comment on the issue for a specific meeting or by adding the "tsc agenda" label to an issue in the [ESLint repository](https://github.com/eslint/eslint).
+Meetings are scheduled through issues on this repository. Agenda items may be added by adding the "tsc agenda" label to an issue in the [ESLint repository](https://github.com/eslint/eslint) or any other repository in the organization. If there is no issue, agenda items may also be added by leaving a comment on the issue for a specific meeting in this repository.
 
 All meetings take place in https://gitter.im/eslint/tsc-meetings/


### PR DESCRIPTION
Only question I have is if I should explicitly say something like "we prefer that agenda items should be represented as issues with tsc agenda label".

Let me know if anything else needs to be changed.