### PR TITLE
Fix: attendance list for 2019-06-06 meeting

### DIFF
--- a/notes/2019/2019-06-06.md
+++ b/notes/2019/2019-06-06.md
@@ -9,7 +9,6 @@ https://gitter.im/eslint/tsc-meetings/archives/2019/06/06
 * Brandon Mills (@btmills) - TSC
 * Toru Nagashima (@mysticatea) - TSC
 * Kai Cataldo (@kaicataldo) - TSC
-* Teddy Katz (@not-an-aardvark) - TSC
 * Ilya Volodin (@ilyavolodin) - TSC
 
 Additionally, the following individuals are not in attendance but support consensus:


### PR DESCRIPTION
I wasn't at today's meeting -- this removes my name from the attendance list.