### PR TITLE
Add 2020-07-02 meeting notes (closes #184)

### DIFF
--- a/notes/2020/2020-07-02.md
+++ b/notes/2020/2020-07-02.md
@@ -1,0 +1,86 @@
+# 2020-July-02 ESLint TSC Meeting Notes
+
+## Transcript
+
+[`2020-07-02-transcript.md`](2020-07-02-transcript.md)
+
+## Attending
+
+* Kai Cataldo (@kaicataldo) - TSC
+* Brandon Mills (@btmills) - TSC
+* Nicholas C. Zakas (@nzakas) -TSC
+* Toru Nagashima (@mysticatea) - TSC
+
+@nzakas moderated, and @btmills took notes and updated issues with resolutions.
+
+## Topics
+
+### [Config cloning and non-serializable rule config values](https://github.com/eslint/eslint/issues/13447)
+
+* Summary by @nzakas:
+
+> Shortly after the v7.3.0 release, we received [an issue](https://github.com/eslint/eslint/issues/13427) that [`eslint-config-airbnb` was breaking](https://github.com/airbnb/javascript/issues/2245) because it used `Infinity` in a rule config.
+> `Infinity` should have been forbidden by the [rule's option schema](https://github.com/benmosher/eslint-plugin-import/blob/296262842b52a50c5b107ba91bb2d13c05b2a104/src/rules/no-cycle.js#L17-L21), but [a bug](https://github.com/ajv-validator/ajv/issues/182) in Ajv, the JSON schema validator that ESLint uses, incorrectly allowed `Infinity` when an `integer` was specified.
+> This was finally caught because the v7.3.0 release included [a change](https://github.com/eslint/eslint/pull/13034) that fixed [an unrelated issue](https://github.com/eslint/eslint/issues/12592) by serializing rule configs.
+> ESLint expects rule configs to be JSON-serializable for consistency between all supported JSON, YAML, and JS `.eslintrc` formats, and it relies on this property in the `--cache` and `--print-config` command line options.
+> Updating `eslint-config-airbnb` to use `Number.MAX_SAFE_INTEGER` instead of `Infinity` is the [ideal solution](https://github.com/eslint/eslint/issues/13427#issuecomment-647733750) but would have taken too long.
+> Since this was the only reported issue and isolated to `eslint-config-airbnb` rather than end-user configs, we [implemented an exception](https://github.com/eslint/eslint/pull/13435) that replaced `Infinity` with `Number.MAX_SAFE_INTEGER` and released it in v7.3.1, which allowed us to preserve the unrelated bug fix.
+
+> After the v7.3.1 release, we received [another issue](https://github.com/eslint/eslint/issues/13447) that [an `eslint-plugin-unicorn` rule](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/6c02ce4e32c84702bcd06e90aa91696366036294/docs/rules/filename-case.md#ignore) was directing users to use regular expression instances, which are not JSON-serializable.
+> Unlike `eslint-config-airbnb`, where the non-serializable value was isolated to a single dependency, end user configs for `eslint-plugin-unicorn` include regular expressions, so fixing all of them is not practical.
+
+* :+1: to reverting from @btmills and @kaicataldo.
+* @btmills asks if we want to warn users about non-serializable values.  
+* @nzakas points out that in most cases, users would be unable to resolve a warning until an alternative has been implemented upstream by a plugin.
+* @kaicataldo asks if the [simple config RFC](https://github.com/eslint/rfcs/pull/9) would enforce serializable configs.
+* @nzakas envisions simple config requiring serializable rule configs for backwards compatibility with `.eslintrc`, and suggests that `RuleTester` could help rule authors catch non-serializable values.
+* @kaicataldo asks and @nzakas confirms the position that a future major release would enforce serializable rule configs for `.eslintrc` and the simple config format. :+1: from @btmills.
+* The 7.4.0 release post should include a summary of this discussion reviewed by at least one TSC member in addition to the author.
+
+**Resolution:**
+
+> We're therefore [reverting the original change](https://github.com/eslint/eslint/pull/13449) for the v7.4.0 release and finding another solution.
+> This will unblock regular linting for users whose rule configs include non-JSON-serializable values, though the `--cache` and `--print-config` command line options may exhibit undefined behavior in those cases.
+> A future major version of ESLint will enforce that rule configs contain only JSON-serializable values, and we anticipate that enhancements to `RuleTester` will help rule authors prepare their schemas for that.
+
+### [RFC Process Enhancements](https://github.com/eslint/tsc-meetings/issues/184#issuecomment-651932224)
+
+#### 1. Should people open an issue first?
+
+* @nzakas: Right now we both have people opening issues unaware that they'll need an RFC, and people who just open RFCs directly. It seems like it would useful to have a single entrypoint to the RFC process. I'd like to suggest that we start the RFC process by asking people to open an issue and gather initial feedback. Assuming the feedback goes well, then they would progress to the RFC writing phase. This has the added benefit of giving us an issue to submit a PR against.
+* :+1: from @kaicataldo and @btmills because the lower barrier to entry for writing an issue is more respectful of contributors' time.
+
+**Resolution**: The RFC process should begin with an initial feedback issue and produce an RFC upon general agreement. @nzakas will update the RFC README for this and any other changes.
+
+#### Competing RFCs
+
+* @nzakas: I'd like to suggest that if there are two or more RFCs aiming to solve the same problem, that those RFCs should be considered together and a direction decided on that approves one and declines the others. I don't want to end up in another situation like with simple config, where I wrote an RFC and then several other competing RFCs were written and approved before we had decided on which direction to go (a new config system vs. incremental changes).
+* @btmills asks for examples of how this would have changed discussion around the simple config RFC and other `.eslintrc` RFCs.
+* @nzakas explains that some incremental `.eslintrc` RFCs made the simple config RFC harder to implement while maintaining backwards compatibility, so with this rule, related RFCs that preclude or make another RFC more difficult would require an explicit directional decision on all related RFCs.
+* :+1: from @btmills and @kaicataldo.
+
+**Resolution**: RFCs aiming to solve the same problem should be considered together to choose the preferred approach. @nzakas will update the README.
+
+#### Time limit for decisions
+
+* @nzakas: I'd also like to suggest that after 120 days, the TSC must decide whether to move forward with an RFC or not. Once again, simple config being an example of the process gone wrong. I don't think we should expect people to continue to defend and respond to comments for an entire year. If someone has put in the time to produce an RFC, we certainly should be able to figure out if it's a direction we want to head in (even with some further feedback and modifications) or not.
+* @nzakas: And 120 days is a somewhat arbitrary suggestion, just felt like around 90 or 120 days would make sense so we could review everything once per quarter
+* @btmills asks if this would force a decision either "not gonna happen" or "directionally if not specifically correct, and we can iron out the specifics in the implementation PR", and @nzakas confirms.
+* @btmills is in favor and suggests (and is willing to write) updates to the RFC documentation to clarify that RFCs need only reach directional consensus to be merged and do not need to be a complete spec. :+1: from @kaicataldo and @nzakas.
+* @kaicataldo feels 120 days is too long and wants to shorten RFC turnaround.
+* @nakas is open to a shorter timeframe but wants to make sure it's feasible given review frequency estimated at around a week. Ember, for example, reviews RFCs once per quarter.
+* @btmills suggests 90 days to start since it's once per quarter and allows 4 review cycles given conservative assumptions. :+1: from @kaicataldo and @nzakas.
+* @kaicataldo confirms 90 days starts from the time the RFC is created, not the prerequisite issue. @nzakas confirms.
+
+**Resolution**: We will make a "go vs no-go" decision on RFCs within 90 days of the RFC being created. RFCs don't need to have all of the details worked out, but they do need to represent the general direction of the proposal clear enough for the TSC to make a decision.
+
+#### Prototype pull requests
+
+* @nzakas: We have a range of what people are doing with respect to prototyping their RFCs and sending pull requests, so I'd like to decide what we want the rule to be. My preference would be to not have people send pull requests with their prototypes because it creates noise in an already noisy area of the repo. Instead, I'd rather see the prototype branch (or fork) referenced directly in the RFC if one is available. That way, those who are interested can try the prototype and we don't mix in prototypes with active development in the pull request list.
+* :+1: from @kaicataldo and @btmills.
+
+**Resolution**: Prototypes for RFCs should live in branches or forks and not pull requests into the main ESLint repo.
+
+### [Scheduled release for July 3rd, 2020](https://github.com/eslint/eslint/issues/13443)
+
+* @kaicataldo will run the release.

--- a/notes/2020/2020-07-02.md
+++ b/notes/2020/2020-07-02.md
@@ -9,7 +9,6 @@
 * Kai Cataldo (@kaicataldo) - TSC
 * Brandon Mills (@btmills) - TSC
 * Nicholas C. Zakas (@nzakas) -TSC
-* Toru Nagashima (@mysticatea) - TSC
 
 @nzakas moderated, and @btmills took notes and updated issues with resolutions.
 


### PR DESCRIPTION
🚧 this does not yet include the transcript. @kaicataldo - let me know how your automation for that is coming along and whether I should run it manually and attach to this PR.

@kaicataldo I structured the notes for the config cloning discussion so that copying the blockquoted parts should give you a decent start on tomorrow's release announcement with links included assuming everyone's happy with the notes.