### PR TITLE
Chore: add reactions to transcripts

### DIFF
--- a/notes/2020/2020-07-16-transcript.md
+++ b/notes/2020/2020-07-16-transcript.md
@@ -3,6 +3,7 @@
 **nzakas:** Hi everyone!
 
 **mdjermanovic:** Hi
+ * 👋 @kaicataldo
 
 **nzakas:** Welcome Milos! 🎉
 
@@ -33,6 +34,7 @@
 **kaicataldo:** Hi all 👋
 
 **nzakas:** Welcome @kaicataldo!
+ * ☺️ @kaicataldo
 
 **nzakas:** All right, let's get started
 
@@ -115,6 +117,7 @@
 **mdjermanovic:** 👍
 
 **nzakas:** Looks like @mysticatea just signed on
+ * 🤞 @btmills
 
 **nzakas:** @mysticatea if you're around, we are deciding on closing the remaining open config-related RFCs now that the simple config RFC has been merged.
 
@@ -173,6 +176,7 @@
 **nzakas:** Sure, we can do that
 
 **btmills:** At some point, I'd suggest that you shadow one of us on a release @mdjermanovic so you see how the process works, whenever's convenient
+ * 👍 @mysticatea, @kaicataldo, @mdjermanovic
 
 **kaicataldo:** I'm available to run the release. Related to this, one thing I'd like to get on the same page about is https://github.com/eslint/eslint/pull/13416. What further work needs to be done before we can land this?
 
@@ -181,6 +185,7 @@
 **mysticatea:** The remaining step is, releasing espree and updating package.json.
 
 **kaicataldo:** Okay, great. In that case, I can commit to reviewing that tonight and doing that work as part of the release.
+ * 👍 @mysticatea
 
 **nzakas:** Awesome, thanks @mysticatea and @kaicataldo . In the future, can we try to do smaller pull requests? The more files touched, the harder it is to merge.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -67,19 +67,10 @@
         }
       }
     },
-    "@babel/runtime-corejs3": {
-      "version": "7.10.4",
-      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.10.4.tgz",
-      "integrity": "sha512-BFlgP2SoLO9HJX9WBwN67gHWMBhDX/eDz64Jajd6mR/UAUzqrNMm99d4qHnVaKscAElZoFiPv+JpR/Siud5lXw==",
-      "requires": {
-        "core-js-pure": "^3.0.0",
-        "regenerator-runtime": "^0.13.4"
-      }
-    },
     "@discordjs/collection": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-0.1.5.tgz",
-      "integrity": "sha512-CU1q0UXQUpFNzNB7gufgoisDHP7n+T3tkqTsp3MNUkVJ5+hS3BCvME8uCXAUFlz+6T2FbTCu75A+yQ7HMKqRKw=="
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-0.1.6.tgz",
+      "integrity": "sha512-utRNxnd9kSS2qhyivo9lMlt5qgAUasH2gb7BEOn6p0efFh24gjGomHzWKMAPn2hEReOPQZCJaRKoURwRotKucQ=="
     },
     "@discordjs/form-data": {
       "version": "3.0.1",
@@ -265,11 +256,6 @@
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
     },
-    "core-js-pure": {
-      "version": "3.6.5",
-      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.6.5.tgz",
-      "integrity": "sha512-lacdXOimsiD0QyNf9BC/mxivNJ/ybBGJXQFKzRekp1WTHoVUWsUHEn+2T8GJAzzIhyOuXA+gOxCVN3l+5PLPUA=="
-    },
     "cross-spawn": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -291,12 +277,9 @@
       }
     },
     "decamelize": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-3.2.0.tgz",
-      "integrity": "sha512-4TgkVUsmmu7oCSyGBm5FvfMoACuoh9EOidm7V5/J2X2djAwwt57qb3F2KMP2ITqODTCSwb+YRV+0Zqrv18k/hw==",
-      "requires": {
-        "xregexp": "^4.2.4"
-      }
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
     },
     "deep-is": {
       "version": "0.1.3",
@@ -310,12 +293,12 @@
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
     },
     "discord-transcript-generator": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/discord-transcript-generator/-/discord-transcript-generator-1.0.3.tgz",
-      "integrity": "sha512-ey+/NCTnYZiI2Wks4Q7xtrPCvtrfC9xG6rFHcMwDh6F/G9rYqTVvdbOUrKhSrPNsLCbgKkAEeYWnEHoQCpU01g==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/discord-transcript-generator/-/discord-transcript-generator-1.1.0.tgz",
+      "integrity": "sha512-9uYg4y2lX0BaJtM7NJn0U05PgjIn6wHE48nlWiFqz76SohCqc7jjHHwx3ow7HQo2pDj78TDLyJSEnn1iD/SzTQ==",
       "requires": {
         "discord.js": "^12.2.0",
-        "yargs": "^15.3.1"
+        "yargs": "^15.4.1"
       }
     },
     "discord.js": {
@@ -938,11 +921,6 @@
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
       "dev": true
     },
-    "regenerator-runtime": {
-      "version": "0.13.5",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.5.tgz",
-      "integrity": "sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA=="
-    },
     "regexpp": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.1.0.tgz",
@@ -1263,17 +1241,9 @@
       }
     },
     "ws": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.3.0.tgz",
-      "integrity": "sha512-iFtXzngZVXPGgpTlP1rBqsUK82p9tKqsWRPg5L56egiljujJT3vGAYnHANvFxBieXrTFavhzhxW52jnaWV+w2w=="
-    },
-    "xregexp": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/xregexp/-/xregexp-4.3.0.tgz",
-      "integrity": "sha512-7jXDIFXh5yJ/orPn4SXjuVrWWoi4Cr8jfV1eHv9CixKSbU+jY4mxfrBwAuDvupPNKpMUY+FeIqsVw/JLT9+B8g==",
-      "requires": {
-        "@babel/runtime-corejs3": "^7.8.3"
-      }
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.3.1.tgz",
+      "integrity": "sha512-D3RuNkynyHmEJIpD2qrgVkc9DQ23OrN/moAwZX4L8DfvszsJxpjQuUq3LMx6HoYji9fbIOBY18XWBsAux1ZZUA=="
     },
     "y18n": {
       "version": "4.0.0",
@@ -1281,12 +1251,12 @@
       "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w=="
     },
     "yargs": {
-      "version": "15.4.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.0.tgz",
-      "integrity": "sha512-D3fRFnZwLWp8jVAAhPZBsmeIHY8tTsb8ItV9KaAaopmC6wde2u6Yw29JBIZHXw14kgkRnYmDgmQU4FVMDlIsWw==",
+      "version": "15.4.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+      "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
       "requires": {
         "cliui": "^6.0.0",
-        "decamelize": "^3.2.0",
+        "decamelize": "^1.2.0",
         "find-up": "^4.1.0",
         "get-caller-file": "^2.0.1",
         "require-directory": "^2.1.1",
@@ -1305,13 +1275,6 @@
       "requires": {
         "camelcase": "^5.0.0",
         "decamelize": "^1.2.0"
-      },
-      "dependencies": {
-        "decamelize": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-          "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
-        }
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "discord-transcript-generator": "^1.0.3",
+    "discord-transcript-generator": "^1.1.0",
     "moment": "^2.27.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Took a couple minutes to update the transcript generator package to now include reactions. I was able to update the last meeting, but trying to run it for earlier meetings is resulting in blank transcripts. It might be that Discord's API only allows for messages to be pulled up to a certain date. I did a little googling and wasn't able to find anything, but I'll dig a bit deeper and see if I can see why it's not working. It does seem to be working generally, though (as demonstrated by running the script for the last meeting).