### PR TITLE
Upgrade: discord-transcript-generator@1.1.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -293,9 +293,9 @@
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
     },
     "discord-transcript-generator": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/discord-transcript-generator/-/discord-transcript-generator-1.1.0.tgz",
-      "integrity": "sha512-9uYg4y2lX0BaJtM7NJn0U05PgjIn6wHE48nlWiFqz76SohCqc7jjHHwx3ow7HQo2pDj78TDLyJSEnn1iD/SzTQ==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/discord-transcript-generator/-/discord-transcript-generator-1.1.1.tgz",
+      "integrity": "sha512-bbURMQAkzdsljDgv+cdQPf83VapPFcjgppIBmnw6jvCQ/lX4rY8Qh8wyIy1R+Z304sO5y7jkw9bXYtXcfsLrew==",
       "requires": {
         "discord.js": "^12.2.0",
         "yargs": "^15.4.1"

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "discord-transcript-generator": "^1.1.0",
+    "discord-transcript-generator": "^1.1.1",
     "moment": "^2.27.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Noticed a [little bug](https://github.com/eslint/tsc-meetings/pull/203/commits/006e55e44c7c1eafa5c090ccb0abb3d1649f05dd) in the formatting of multiple reactions. Updated it manually for this week's transcript but am bumping the version here for next time.