### PR TITLE
Chore: Remove deprecated set-env from transcript workflow

### DIFF
--- a/.github/workflows/generate-transcript.yml
+++ b/.github/workflows/generate-transcript.yml
@@ -32,7 +32,7 @@ jobs:
             echo "Files changed."
             git add .
             git commit -m 'Add ${{ github.event.issue.title }} transcript'
-            echo "::set-env name=TRANSCRIPT_GENERATED::true"
+            echo "TRANSCRIPT_GENERATED=true" >> $GITHUB_ENV
           fi
       - name: Create Pull Request
         if: env.TRANSCRIPT_GENERATED == 'true'


### PR DESCRIPTION
The `::set-env` command was [deprecated](https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/) due to a security vulnerability and replaced with [environment files](https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-commands-for-github-actions#environment-files). This caused transcript generation for the 2020-11-19 meeting [to fail](https://github.com/eslint/tsc-meetings/actions/runs/380143250).

There's not a great way to test this prior to merging it, so there's a bit of YOLOing going on here. Once this is approved, I'll merge then reopen and close #219 to trigger the workflow. 🤞