### PR TITLE
Upgrade: Create Pull Request action to fix set-env error

### DIFF
--- a/.github/workflows/generate-transcript.yml
+++ b/.github/workflows/generate-transcript.yml
@@ -36,7 +36,7 @@ jobs:
           fi
       - name: Create Pull Request
         if: env.TRANSCRIPT_GENERATED == 'true'
-        uses: peter-evans/create-pull-request@v2
+        uses: peter-evans/create-pull-request@v3
         with:
           commit-message: Add ${{ github.event.issue.title }} transcript
           title: Add ${{ github.event.issue.title }} transcript


### PR DESCRIPTION
The fix in #223 allowed the last action run to successfully create #224, but it [failed](https://github.com/eslint/tsc-meetings/runs/1465153998?check_suite_focus=true) before the job completed due to an old version of the Create Pull Request action still using `::set-env`.

[Release v3.4.1](https://github.com/peter-evans/create-pull-request/releases/tag/v3.4.1) removed the deprecated `::set-env` command. We shouldn't be affected by any breaking changes in the [v3 release](https://github.com/peter-evans/create-pull-request/releases/tag/v3.0.0).