### PR TITLE
chore: Replace Gitter link with Discord link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,7 @@
 # ESLint Technical Steering Committee (TSC) Meetings
 
-[![Join the chat at https://gitter.im/eslint/tsc-meetings](https://badges.gitter.im/eslint/tsc-meetings.svg)](https://gitter.im/eslint/tsc-meetings?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
-
 The ESLint TSC meets every other week to discuss issues related to the project. This repository contains the meeting notes along with other related information.
 
 Meetings are scheduled through issues on this repository. Agenda items may be added by adding the "tsc agenda" label to an issue in the [ESLint repository](https://github.com/eslint/eslint) or any other repository in the organization. If there is no issue, agenda items may also be added by leaving a comment on the issue for a specific meeting in this repository.
 
-All meetings take place in https://gitter.im/eslint/tsc-meetings/
+All meetings take place in [Discord](https://eslint.org/chat).


### PR DESCRIPTION
Since meetings have moved from Gitter to Discord, this PR replaces the Gitter link and badge with a link to the Discord server.

shields.io has a Discord badge you could use as well, but it looks like it would need a Discord server admin to set it up:
https://shields.io/category/chat