### PR TITLE
chore: use `setup-node@v2` in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,9 +13,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Setup Node.js
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v2
         with:
-          node-version: 12
+          node-version: '14.x'
       - name: Install dependencies
         run: npm install
       - name: Lint Files

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v2
         with:
-          node-version: '14.x'
+          node-version: '16.x'
       - name: Install dependencies
         run: npm install
       - name: Lint Files

--- a/.github/workflows/generate-transcript.yml
+++ b/.github/workflows/generate-transcript.yml
@@ -9,9 +9,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Setup Node.js
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v2
         with:
-          node-version: 12
+          node-version: '14.x'
       - name: Install dependencies
         run: npm install
       - name: Generate transcript

--- a/.github/workflows/generate-transcript.yml
+++ b/.github/workflows/generate-transcript.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v2
         with:
-          node-version: '14.x'
+          node-version: '16.x'
       - name: Install dependencies
         run: npm install
       - name: Generate transcript


### PR DESCRIPTION

Update the `setup-node` action to `v2` for CI node workflows.

https://github.com/marketplace/actions/setup-node-js-environment