### PR TITLE
ci: Run on main branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,11 @@ name: CI
 on:
   push:
     branches:
+      - main
       - master
   pull_request:
     branches:
+      - main
       - master
 jobs:
   lint:


### PR DESCRIPTION
Refs: #309

This currently includes both `main` and `master`. After I use GitHub's branch rename feature to rename the default branch to `main`, I'll open a follow-up PR that removes `master`.