### PR TITLE
ci: Upgrade eslint-config-eslint to fix peer conflict

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
       },
       "devDependencies": {
         "eslint": "^7.3.1",
-        "eslint-config-eslint": "^6.0.0",
+        "eslint-config-eslint": "^7.0.0",
         "eslint-plugin-jsdoc": "^28.6.1",
         "eslint-plugin-node": "^11.1.0"
       }
@@ -538,16 +538,16 @@
       }
     },
     "node_modules/eslint-config-eslint": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-eslint/-/eslint-config-eslint-6.0.0.tgz",
-      "integrity": "sha512-dZ+eNtuU8V6+SbXgXjUf11/7Bv4EXzIqn4DxA3Ou1YklwFz31veKYTjzF9uYejUQQjOMpLHTEKWMGSmHAoh4wg==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-eslint/-/eslint-config-eslint-7.0.0.tgz",
+      "integrity": "sha512-gxUttladfTQaJKmSh9jbrN4Qba27yYBVwp0YsaOqjEWtOZYtc+MOgoWFh2x4Ewxjqr8sZZS1yTguXgoktzXOvQ==",
       "dev": true,
       "engines": {
-        "node": "^8.10.0 || ^10.13.0 || >=11.10.1"
+        "node": "^10.12.0 || >=12.0.0"
       },
       "peerDependencies": {
-        "eslint-plugin-jsdoc": "^15.9.5",
-        "eslint-plugin-node": "^9.0.0"
+        "eslint-plugin-jsdoc": ">=22.1.0",
+        "eslint-plugin-node": ">=11.1.0"
       }
     },
     "node_modules/eslint-plugin-es": {
@@ -2158,9 +2158,9 @@
       }
     },
     "eslint-config-eslint": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-eslint/-/eslint-config-eslint-6.0.0.tgz",
-      "integrity": "sha512-dZ+eNtuU8V6+SbXgXjUf11/7Bv4EXzIqn4DxA3Ou1YklwFz31veKYTjzF9uYejUQQjOMpLHTEKWMGSmHAoh4wg==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-eslint/-/eslint-config-eslint-7.0.0.tgz",
+      "integrity": "sha512-gxUttladfTQaJKmSh9jbrN4Qba27yYBVwp0YsaOqjEWtOZYtc+MOgoWFh2x4Ewxjqr8sZZS1yTguXgoktzXOvQ==",
       "dev": true,
       "requires": {}
     },

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "devDependencies": {
     "eslint": "^7.3.1",
-    "eslint-config-eslint": "^6.0.0",
+    "eslint-config-eslint": "^7.0.0",
     "eslint-plugin-jsdoc": "^28.6.1",
     "eslint-plugin-node": "^11.1.0"
   }


### PR DESCRIPTION
`eslint-config-eslint@6.0.0` has a peer dependency on `eslint-plugin-jsdoc@^15.9.5`, whereas `package.json` has a `devDependency` on `eslint-plugin-jsdoc@^28.6.1`. Those ranges are in conflict.

This change upgrades to `eslint-config-eslint@7.0.0`, which changes the peer dependency to `eslint-plugin-jsdoc@>=22.1.0`, resolving the conflict.

This should fix the CI failures seen in #355 and #356. This peer dependency version range conflict was previously being ignored, but a behavior change in npm 8.6.0 started reporting it. Whether that's a backwards-incompatible change in a semver-minor version is left as a question for the reader.