### PR TITLE
docs: Add 2024-11-14 meeting notes

### DIFF
--- a/notes/2024/2024-11-14.md
+++ b/notes/2024/2024-11-14.md
@@ -35,14 +35,13 @@ We got a response on the original issue that the performance is about the same. 
 **Action Items:**
 
 * folks should compare runtime between these two versions and report back with findings
-* @mdjermanovic will ask in [this issue](https://github.com/eslint/eslint/issues/19025) whether they notice better performance with `9.14.0`
 
 
 ### [Lint multiple files in parallel [$500]](https://github.com/eslint/eslint/issues/3565)
 
 **Action Items:** @fasttime will prepare a RFC
 
-### Scheduled release for November 1st, 2024
+### Scheduled release for November 15th, 2024
 
 **Action Items:**
 

--- a/notes/2024/2024-11-14.md
+++ b/notes/2024/2024-11-14.md
@@ -1,0 +1,52 @@
+# 2024-11-14 ESLint TSC Meeting Notes
+
+## Transcript
+
+[`2024-11-14-transcript.md`](2024-11-14-transcript.md)
+
+## Attending
+
+- Nicholas C. Zakas (@nzakas) - TSC
+- Milos Djermanovic (@mdjermanovic) - TSC
+- Francesco Trotta (@fasttime) - TSC
+
+@nzakas moderated, and @sam3k took notes.
+
+## Topics
+
+### Statuses
+
+* **@nzakas:** has been working on the CSS plugin primarily, with a bit of followup work on the JSON plugin, and just started an extends RFC.
+* **@mdjermanovic:** has been mostly reviewing PRs. Also updated `@eslint/compat` to support legacy `schema` properties.
+* **@fasttime:** mostly busy with triaging issues and reviewing RFCs. Also finished the fix on ignoring files on a different drive on Windows.
+
+
+### RFC Duty Schedule
+
+* November 11: @nzakas
+* November 18: @mdjermanovic
+* November 25: @fasttime 
+* December 2: @nzakas
+
+### Benchmark Runtime of `v9.12.0` to `v9.14.0`
+
+We got a response on the original issue that the performance is about the same. (About the same as before v9.12)
+
+**Action Items:**
+
+* folks should compare runtime between these two versions and report back with findings
+* @mdjermanovic will ask in [this issue](https://github.com/eslint/eslint/issues/19025) whether they notice better performance with `9.14.0`
+
+
+### [Lint multiple files in parallel [$500]](https://github.com/eslint/eslint/issues/3565)
+
+**Action Items:** @fasttime will prepare a RFC
+
+### Scheduled release for November 1st, 2024
+
+**Action Items:**
+
+- @mdjermanovic will release:
+  - `eslint`
+  - `@eslint/eslintrc`
+  - `@eslint/js`


### PR DESCRIPTION
Closes #544 

Note: I've omitted the conversation regarding some last minute PRs we wanted to merged before the deployment as a) it was a bit hard to follow and b) seem unnecessary to the notes. Let me know your thoughts.