### PR TITLE
chore: add `.git-blame-ignore-revs`

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# #641 chore: introduce `prettier`
+ee8c8042e16a194b77f044351be58fd192263cbf


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

## Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

## What is the purpose of this pull request?

In this PR, I've added `.git-blame-ignore-revs` as a follow-up to #641.

Adding a [`.git-blame-ignore-revs`](https://docs.github.com/en/repositories/working-with-files/using-files/viewing-and-understanding-files#ignore-commits-in-the-blame-view) file prevents the squash-merged Prettier commit from appearing in GitHub's blame view.

I followed the same format used in the `eslint` repository: https://github.com/eslint/eslint/blob/main/.git-blame-ignore-revs

cc. @mdjermanovic 

## What changes did you make? (Give an overview)

In this PR, I've added `.git-blame-ignore-revs` as a follow-up to #641.

## Related Issues

Ref: https://github.com/eslint/eslint/pull/19538

<!-- include tags like "fixes #123" or "refs #123" -->

## Is there anything you'd like reviewers to focus on?

N/A