### PR TITLE
ci: declare contents:read on CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
     pull_request:
         branches:
             - main
+permissions:
+    contents: read
+
 jobs:
     lint:
         name: Lint Files


### PR DESCRIPTION
This declares `permissions: contents: read` at the workflow level of `.github/workflows/ci.yml`. The two CI jobs check out the repo, set up Node, and run lint/build/format steps. None of them write to the repository or call a GitHub API requiring more than read on contents.

Worth doing because of the runtime supply-chain threat surfaced by CVE-2025-30066 (the March 2025 `tj-actions/changed-files` attack). When a compromised third-party action exfiltrates `GITHUB_TOKEN` from workflow logs, the leaked token retains whatever scope was issued. Pinning each workflow at the minimum bounds that authority regardless of the repo or org default, gives drift protection if the default ever widens, and is what OpenSSF Scorecard's Token-Permissions check looks for explicitly. The TSC meetings repo also publishes the agendas/notes so external readers occasionally land here, and the small in-file declaration is the simplest way to make the security posture self-documenting.

YAML validated locally with `yaml.safe_load`.
