### PR TITLE
fix: Avoid issue-title command injection in transcript commit step

### DIFF
--- a/.github/workflows/generate-transcript.yml
+++ b/.github/workflows/generate-transcript.yml
@@ -28,13 +28,15 @@ jobs:
                   git config user.email "eslint[bot]@users.noreply.github.com"
                   git config user.name "ESLint Bot"
             - name: Commit generated transcript (if changed)
+              env:
+                  ISSUE_TITLE: ${{ github.event.issue.title }}
               run: |
                   if [ -z "$(git status --porcelain)" ]; then
                     echo "No changed files. Skipping commit."
                   else
                     echo "Files changed."
                     git add .
-                    git commit -m 'Add ${{ github.event.issue.title }} transcript'
+                    git commit -m "Add $ISSUE_TITLE transcript"
                     echo "TRANSCRIPT_GENERATED=true" >> $GITHUB_ENV
                   fi
             - name: Create Pull Request


### PR DESCRIPTION
Hi. I work on software supply chain security and was reviewing Actions workflows for untrusted input reaching a shell. This is a one-line hardening change.

`generate-transcript.yml` runs on `issues` (closed), and the commit step builds its message as `git commit -m 'Add ${{ github.event.issue.title }} transcript'`. GitHub expands `${{ }}` into the script text before bash executes, so an issue title like `` `id` `` or `$(...)` would run as a command. The job has `contents: write` and a Discord bot token in the environment, so the title is evaluated in a fairly privileged context. A title needs the `tsc meeting` label to reach this step, but the label is applied by a maintainer to an issue whose title an outside user chose, so the value is still attacker-influenced.

The fix routes the title through an `ISSUE_TITLE` environment variable and uses `"$ISSUE_TITLE"` in the message. The "Generate transcript" step right above already does exactly this, so it is just making the commit step consistent. I left the `create-pull-request` inputs alone since those are action inputs, not shell.