### PR TITLE
fix: unwrap messages in discord transcript generator

### DIFF
--- a/scripts/discord-transcript-generator.js
+++ b/scripts/discord-transcript-generator.js
@@ -165,7 +165,9 @@ module.exports = async function generateTranscript({
 						const channel = await client.channels.fetch(id);
 						const messages = await fetchMessages(channel, date);
 						if (messages.length === 0) {
-							throw new Error('There were no messages at the specified date');
+							throw new Error(
+								"There were no messages at the specified date",
+							);
 						}
 
 						await fs.writeFile(

--- a/scripts/discord-transcript-generator.js
+++ b/scripts/discord-transcript-generator.js
@@ -81,13 +81,12 @@ async function generateContent(messages, date, name) {
 
 /**
  * Returns sorted messages of the given date.
- * @param {Array<number, Message>} messages Channel messages
+ * @param {Array<Message>} messages Channel messages
  * @param {string} date Calendar date of the wanted messages
  * @returns {Message[]} Sorted by created timestamp
  */
 function getTranscriptMessages(messages, date) {
 	return messages
-		.map(([, message]) => message)
 		.filter(message => messageMatchesDate(message, date))
 		.sort((a, b) => a.createdTimestamp - b.createdTimestamp);
 }
@@ -108,6 +107,7 @@ async function fetchMessages(channel, date) {
 			await channel.messages.fetch(
 				messages.length ? { before: messages[0].id } : void 0,
 			),
+			([, message]) => message,
 		);
 
 		if (!batch.length) {

--- a/scripts/discord-transcript-generator.js
+++ b/scripts/discord-transcript-generator.js
@@ -12,12 +12,12 @@ const path = require("node:path");
 const { Client, GatewayIntentBits, Partials } = require("discord.js");
 
 /**
- * Converts a date string representation to an UTC date offset.
- * @param {string} dateString String representation of the string
+ * Converts a date representation to an UTC date offset.
+ * @param {string | number} dateSpecifier Calendar date from issue title or UNIX timestamp from message
  * @returns {number} UTC date offset
  */
-function getUTCDate(dateString) {
-	const dateInstance = new Date(dateString);
+function getUTCDate(dateSpecifier) {
+	const dateInstance = new Date(dateSpecifier);
 
 	return Date.UTC(
 		dateInstance.getYear(),
@@ -29,7 +29,7 @@ function getUTCDate(dateString) {
 /**
  * Returns true for messages created at the given date.
  * @param {Message} message Discord message
- * @param {Date} date Date to compare to
+ * @param {string} date Calendar date of the wanted messages
  * @returns {boolean} True iff message created on date
  */
 function messageMatchesDate(message, date) {
@@ -40,7 +40,7 @@ function messageMatchesDate(message, date) {
 /**
  * Generates a transcript based on the given channel messages for a given date.
  * @param {Message[]} messages Channel messages
- * @param {Date} date Date of the messages
+ * @param {string} date Calendar date of the wanted messages
  * @param {string} name Name of the transcript
  * @returns {Promise<string>} Generated transcript
  */
@@ -81,12 +81,13 @@ async function generateContent(messages, date, name) {
 
 /**
  * Returns sorted messages of the given date.
- * @param {Message[]} messages Channel messages
- * @param {Date} date Date of the messages
+ * @param {Array<number, Message>} messages Channel messages
+ * @param {string} date Calendar date of the wanted messages
  * @returns {Message[]} Sorted by created timestamp
  */
 function getTranscriptMessages(messages, date) {
 	return messages
+		.map(([, message]) => message)
 		.filter(message => messageMatchesDate(message, date))
 		.sort((a, b) => a.createdTimestamp - b.createdTimestamp);
 }
@@ -94,7 +95,7 @@ function getTranscriptMessages(messages, date) {
 /**
  * Fetches messages of the channel of the given date.
  * @param {Channel} channel Channel to get the messages from
- * @param {Date} date Date of the messages
+ * @param {string} date Calendar date of the wanted messages
  * @returns {Promise<Message[]>} Fetched messages
  */
 async function fetchMessages(channel, date) {
@@ -163,6 +164,9 @@ module.exports = async function generateTranscript({
 					try {
 						const channel = await client.channels.fetch(id);
 						const messages = await fetchMessages(channel, date);
+						if (messages.length === 0) {
+							throw new Error('There were no messages at the specified date');
+						}
 
 						await fs.writeFile(
 							transcriptPath,

--- a/scripts/discord-transcript-generator.js
+++ b/scripts/discord-transcript-generator.js
@@ -99,13 +99,14 @@ function getTranscriptMessages(messages, date) {
  */
 async function fetchMessages(channel, date) {
 	let messages = [];
+	let lastId = null; // Needed if there are no matching messages in the batch (-> "messages" still empty)
 
 	// Discord's API limits fetching messages to 50 at a time. Continue requesting batches
 	// until we either have no messages or find a message from a previous date.
 	while (true) {
 		const batch = Array.from(
 			await channel.messages.fetch(
-				messages.length ? { before: messages[0].id } : void 0,
+				lastId !== null ? { before: lastId } : void 0,
 			),
 			([, message]) => message,
 		);
@@ -114,9 +115,10 @@ async function fetchMessages(channel, date) {
 			break;
 		}
 
+		lastId = batch.at(-1).id;
 		messages = [...getTranscriptMessages(batch, date), ...messages];
 
-		if (!messageMatchesDate(batch.at(-1), date)) {
+		if (getUTCDate(batch.at(-1).createdTimestamp) < getUTCDate(date)) {
 			break;
 		}
 	}


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### AI acknowledgment

- [x] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request?
Fix the empty transcripts (see #709).
The problem seems to have been that messages is an array of tuples `[id, message]` instead of an array of messages (was likely an API or library change).

#### What changes did you make? (Give an overview)
- Unwrap the messages from the tuple
- Updated the types and descriptions of the passed `date` as it is not a date instance but a calendar date string
- Throw an error when no messages match, so it does not create an empty transcript.

#### Related Issues

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?
