### PR TITLE
docs: Add missing meeting transcripts

### DIFF
--- a/notes/2025/2025-10-02-transcript.md
+++ b/notes/2025/2025-10-02-transcript.md
@@ -1,0 +1,219 @@
+# 10/02/2025 ESLint TSC Meeting Transcript
+
+**nzakas:** Howdy!
+
+**fasttime:** Hi 👋
+
+**mdjermanovic:** Hi!
+
+**nzakas:** Just pulling up the notes from last time
+
+**nzakas:** Okay, doesn't look like anything to follow up on.
+
+**nzakas:** Let's start with statuses. I've spent the last couple days looking into the eslint.org bandwidth stuff. I wrote the "What's coming in v10" post and have been working on updating the types in `eslint` to use `@eslint/core`.
+
+**mdjermanovic:** I finished work on changes in eslint-scope and eslint regarding handling of global variables, and was reviewing PRs
+
+**fasttime:** I was mostly busy reviewing PRs and issues
+
+**nzakas:** Okay, let's discuss availability the next couple weeks. I'm still at 0.5-1 hours per week day.
+
+**mdjermanovic:** I expect to work around 2 hours each day
+
+**fasttime:** I should be available about 9 hours per week the next two weeks.
+
+**nzakas:** RFC Duty:
+This week - @nzakas 
+Oct 6 - @mdjermanovic 
+Oct 13 - @fasttime
+ * 👍 @mdjermanovic, @fasttime
+
+**nzakas:** Okay, no issues or PRs are flagged, so let's start by discussing the bandwidth issues we've had the last few days on eslint.org.
+
+**nzakas:** To summarize: we got an email from Netlify saying we'd already used up 50% of our bandwidth for the month, and indeed, we saw bandwidth usage jump by more than 50x starting September 25.
+
+**nzakas:** I posted on Twitter to see if anyone could help, and someone from Netlify (Elad Rosenheim) reached out to say that it looked like we were getting a ton of requests from China directed at `https://eslint.org/feed.xml`
+
+**nzakas:** These had suspicious user agents, specifically, Chrome 58.
+
+**nzakas:** The other problem is that `feed.xml` was a large file (over 600kb!), so each request really added to the bandwidth.
+
+**nzakas:** The problem was that `feed.xml` was including every blog post we ever published on eslint.org.
+
+**nzakas:** We fixed that in https://github.com/eslint/eslint.org/pull/795 to have just the most recent ten posts.
+
+**nzakas:** So that reduces the file size.
+
+**nzakas:** I also added a firewall rule to block all traffic from China until we could do something more targeted. Elad recommended using an Edge function on `feed.xml` to disallow requests from China just on that file.
+
+**nzakas:** That's this PR: https://github.com/eslint/eslint.org/pull/796
+
+**nzakas:** Once this is merged, we can remove the firewall block to once again allow requests from China for anything besides `feed.xml`
+ * 👍 @mdjermanovic
+
+**nzakas:** We are on a donated plan from Netlify so definitely don't want to go over the bandwidth allowance. 🙂
+
+**mdjermanovic:** We currently have ~350GB till Oct 19. That should cover our usual bandwidth
+ * 👍 @nzakas
+
+**nzakas:** Any other thoughts, questions, comments about this?
+
+**mdjermanovic:** It would be nice to have some notification when there are spikes in bandwidth
+
+**fasttime:** Just curious if there's a way to see which requests are causing traffic without reaching out to Netlify?
+
+**mdjermanovic:** Not sure if there's such feature available
+
+**nzakas:** No there isn't.
+ * 👍 @fasttime
+
+**nzakas:** Okay, next agenda item:
+
+> Agenda item: I'm seeing more simple issue requests that are being parked in "Feedback Needed" waiting for other folks to respond (example: [eslint/eslint#20165](https://github.com/eslint/eslint/issues/20165)). This seems unnecessary when the request is fairly straight forward and unlikely to be met with concerns from other team members. I'd like to suggest that TSC members mark issues as accepted that are low-risk without moving to "Feedback Needed". We should reserve "Feedback Needed" for controversial, large, breaking, or other types of changes that involve some amount of risk.
+
+**nzakas:** My goal is just to avoid blocking small changes while waiting for consensus. "Feedback Needed" was intended for something that really needed input to make a decision but it seems to have become a parking lot for most changes.
+
+**fasttime:** Sounds good to me 👍
+
+**mdjermanovic:** No objections from my side
+
+**nzakas:** Okay, we've decided to reserve "Feedback Needed" for larger decisions. TSC members can proactively mark smaller changes they agree with as "accepted"
+ * 👍 @mdjermanovic, @fasttime
+
+**nzakas:** Any other issues before we discuss v10?
+
+**fasttime:** Nothing from my side.
+
+**mdjermanovic:** Nothing from my side, too
+
+**nzakas:** Okay, then let's discuss v10:
+https://github.com/orgs/eslint/projects/6
+
+**nzakas:** I noticed there are two new issues on the board. I'd like us first to discuss if we can lock down v10 now. Can we agree that after today we will not consider any more features for v10?
+ * 👍 @mdjermanovic, @fasttime
+
+**nzakas:** Great, we've agreed that the issues for v10 will be finalized today and anything else will have to wait for v11.
+ * 👍 @mdjermanovic, @fasttime
+
+**nzakas:** First issue:
+https://github.com/eslint/eslint/issues/20171
+
+**mdjermanovic:** I'm in favor of removing rules that were deprecated in ESLint < 8
+
+**mdjermanovic:** But wouldn't be opposed to postponing this to v11
+
+**nzakas:** I'd prefer to defer to v11. I'm not in a hurry to remove deprecated rules.
+
+**fasttime:** I'm also fine with removing all deprecated rules so far in v11.
+
+**mdjermanovic:** Okay, then v11
+
+**nzakas:** Okay, we've decided to move this to v11.
+ * 👍 @mdjermanovic, @fasttime
+
+**nzakas:** Next item:
+https://github.com/eslint/js/issues/697
+
+**mdjermanovic:** I'm in favor
+
+**fasttime:** Makes sense to me 👍
+
+**nzakas:** 👍
+
+**nzakas:** We've agreed to remove the `nodejsScope` from escope for v10.
+ * 👍 @mdjermanovic, @fasttime
+
+**nzakas:** Anything else v10-related that we need to discuss?
+
+**mdjermanovic:** Nothing in particular from my side for today
+
+**fasttime:** Nothing from me.
+
+**nzakas:** I think we need to complete the changes to escope and espree before we can consider a prerelease, so it looks like we're not ready at this point. Agree?
+
+**mdjermanovic:** Agreed, there's more work left on those
+
+**nzakas:** Then we'll re-evaluate at the next TSC meeting.
+ * 👍 @mdjermanovic, @fasttime
+
+**nzakas:** Let's move on to Contributor Pool
+
+**nzakas:** https://github.com/eslint/tsc-meetings/blob/main/notes/2025/2025-10-01-contributor-pool.md
+
+**nzakas:** Going to run this through ye olde Chat GPT...
+
+**nzakas:** | Contributor   | PRs | Payout |
+|---------------|-----|--------|
+| Pixel998      | 17  | $1,350 |
+| jaymarvelz    | 4   | $850   |
+| thecalamiity  | 2   | $450   |
+| sethamus      | 1   | $200   |
+| SwetaTanwar   | 1   | $250   |
+| ntnyq         | 1   | $175   |
+| Amnish04      | 1   | $600   |
+| TKDev7        | 1   | $600   |
+
+**nzakas:** For sethamus, I think $100 is appropriate. It was a one-line code change plus tests.
+ * 👍 @mdjermanovic, @fasttime
+
+**fasttime:** What about ntnyq? Are we fine with $175?
+
+**mdjermanovic:** Maybe $50 instead?
+
+**fasttime:** If it's okay to reward with less than $100, then okay.
+
+**nzakas:** Our minimum is $100
+
+**fasttime:** Then $100 I'd say.
+ * 👍 @mdjermanovic
+
+**nzakas:** Pixel998 I'd lower to $800. A lot of small PRs in the bunch.
+ * 👍 @mdjermanovic, @fasttime
+
+**nzakas:** What about the others?
+
+**mdjermanovic:** Looks like Chat GPT apprecieates new rules. Maybe $600 is too high for this rule? https://github.com/eslint/markdown/pull/433
+
+**nzakas:** Maybe $300 for that?
+ * 👍 @fasttime
+
+**nzakas:** And for Amnish04? That's also one rule.
+
+**mdjermanovic:** That's fairly more complex one, with autofixes included.
+ * 👍 @fasttime
+
+**nzakas:** Okay, so we'll keep that at $600. Are we happy with the rest?
+ * 👍 @mdjermanovic, @fasttime
+
+**mdjermanovic:** The rest look good to me
+ * 👍 @fasttime
+
+**nzakas:** Okay, I'll let them know.
+
+**nzakas:** Let's talk about the release tomorrow
+
+**fasttime:** I can do tomorrow's release.
+ * 🙏 @nzakas
+
+**mdjermanovic:** Thanks!
+
+**fasttime:** It will be just `@eslint/js` and `eslint` I think.
+ * 👍 @nzakas, @mdjermanovic
+
+**nzakas:** I'd like to make sure this blog post goes out tomorrow with the release:
+https://github.com/eslint/eslint.org/pull/792
+
+**fasttime:** Good idea. I will also review it tomorrow.
+
+**mdjermanovic:** I'll re-review it tomorrow too. I left a suggestion for one more paragraph
+
+**nzakas:** Yeah...I'm still not sure the change to scope manager is worth mentioning in this post considering there's only one alternative scope manager we know of and they're already on the issue.
+
+**mdjermanovic:** Okay, if typecript-eslint is already aware of the change, and we don't know any other scope managers, then it's fine to leave that out
+ * 👍 @nzakas, @fasttime
+
+**nzakas:** And with that, I think we're done. Thanks everyone! (and thanks @sam3k_ for the notes)
+
+**mdjermanovic:** Thanks! 👋
+
+**fasttime:** Thanks! Bye 👋

--- a/notes/2025/2025-11-13-transcript.md
+++ b/notes/2025/2025-11-13-transcript.md
@@ -1,0 +1,339 @@
+# 11/13/2025 ESLint TSC Meeting Transcript
+
+**mdjermanovic:** Hi!
+
+**fasttime:** Hi!
+
+**nzakas:** Howdy!
+
+**nzakas:** Let me pull up last meeting's notes
+
+**nzakas:** Looks like no action items to follow up on. So let's start with statuses.
+
+I've been working on the "remove eslintrc" PR and other misc v10 tasks.
+
+**mdjermanovic:** I was focused on preparing the first v10 prerelease
+
+**fasttime:** I was mostly busy with reviews and I prepared a PR to update `@types/eslint-scope` to v9.
+
+**nzakas:** Next, let's talk availability the next two weeks. I'll mostly be 0.5-1 hours per weekday except for November 27-28, during which I'll be offline.
+
+**mdjermanovic:** I expect to be available around 2 hours each day
+
+**fasttime:** I should be available 7-9 hours per week
+
+**nzakas:** RFC Duty:
+This week - @nzakas 
+Nov 17 - @mdjermanovic 
+Nov 24 - @fasttime
+ * 👍 @mdjermanovic, @fasttime
+
+**nzakas:** Okay, we've got a bunch of agenda items. Let's start with the non-v10 ones and then we'll move on to the v10 ones.
+
+**nzakas:** > Agenda item: Let's review recent sponsorship and spending data. Right now, we are receiving $10,737.04 in recurring monthly sponsorships. For the month of October, we paid out nearly $22,000 just for maintenance and development (we haven't yet done Contributor Pool for October). While we have the reserves to cover this, we need to watch this closely going forward as spending over $10,000 more per month than we're bringing in isn't sustainable.
+
+**nzakas:** So our reserve balance right now is $156,432.03, but I believe there are still a couple of expenses left to be paid.
+
+**nzakas:** If this spending rate continues, that gives us a little over a year before we run through the reserves.
+
+**mdjermanovic:** We are currently at around -$40,000 for this year (counting thanks.dev amount we haven't transferred yet)
+
+**nzakas:** Which is roughly on pace with the nearly -$60,000 we had last year.
+
+**nzakas:** My first question: At what reserve level do we feel like we need to make changes to our spending?
+
+**mdjermanovic:** Yeah, we might be better than last year but still tens of thousands below
+
+**fasttime:** The earlier the better I'd say, but not sure what action would be most appropriate.
+
+**nzakas:** I don't mind spending down some reserve, it doesn't do us any good sitting there, but there will reach a point where we can't keep doing that.
+
+**nzakas:** So I'd propose once the reserve hits $120,000 that we institute some changes.
+ * 👍 @mdjermanovic
+
+**nzakas:** We don't need to decide on those changes right now, but some obvious ideas include:
+
+1. Lowering per-hour rates
+2. Capping the amount any one contributor can be paid in a month
+
+**mdjermanovic:** Sounds good to me. We were aiming to have a two-years reserve, and the trend is that we are at about -$60,000 per year, which makes $120,000 being a two-years reserve
+
+**nzakas:** That is true so long as 1) we don't lose any more sponsorships and 2) we don't continue spending $12,000 per month over income.
+
+**fasttime:** So, we will postpone the question to when we hit $120,000 reserve?
+ * 👍 @nzakas, @mdjermanovic
+
+**nzakas:** I do think we need to be more public about asking for sponsorships going forward, probably with a blog post right after we release the 2025 year in review.
+ * 👍 @mdjermanovic, @fasttime
+
+**nzakas:** Okay, we'll revisit this topic when reserves hit $120,000.
+ * 👍 @mdjermanovic, @fasttime
+
+**nzakas:** Next item:
+https://github.com/eslint/rewrite/issues/310
+
+**nzakas:** https://github.com/eslint/rewrite/issues/310#issuecomment-3517530512
+
+**nzakas:** Do we want to change the type of `data` for fixes and suggestions from `unknown` to `string|number|boolean|bigint`?
+
+**fasttime:** I'm not sure if that's necessary. I can imagine rules passing arrays or Date objects as placeholder values. Maybe also null or undefined.
+
+**nzakas:** The problem with things like arrays, objects, dates, etc., is that the output may not be what people expect. We could definitely include null and undefined in the type, though.
+
+**nzakas:** I don't have a strong opinion on this.
+
+**fasttime:** I also don't feel strong about this.
+
+**mdjermanovic:** I wouldn't mind requiring just a `string` as that's how the value will be used
+
+**fasttime:** Do you mean, enforcing in code, not only in the types, that values are string?
+
+**nzakas:** We already have a lot of rules passing numbers, though, and I don't see a good reason to force people to cast as a string.
+
+**mdjermanovic:** I'm not sure if we actually have core tests with non-string values, it might be just working by chance
+
+**nzakas:** I explained in the linked comment. 🙂 We're using `.replace()` with a function and returning the raw value from `data`. `.replace()` coerces those values to string.
+
+**nzakas:** So primitive values always work as expected
+
+**mdjermanovic:** Yeah, I know it works, not sure if it was actually meant to work or works by chance since we are interpolating data that way
+
+**nzakas:** Either way, it is the way it works now and I think we want to codify that behavior as best we can.
+
+**nzakas:** So to me, specifying the type as the union of primitive types makes sense.
+
+**nzakas:** Otherwise I think forcing people to cast everything to strings even though the functionality hasn't changed is just an exercise with no discernable value.
+
+**mdjermanovic:** Then I think primitive types is a good compromise. Passing objects should be rare
+
+**nzakas:** Okay, so `string|number|boolean|bigint|null|undefined`?
+
+**fasttime:** Works for me.
+
+**mdjermanovic:** Works for me too
+
+**nzakas:** All right, we've agreed to change the type for both fix and suggestions `data` to `string|number|boolean|bigint|null|undefined`
+ * 👍 @mdjermanovic, @fasttime
+
+**mdjermanovic:** I think we should also add unit tests in eslint/eslint to make sure it works if we change the interpolation algorithm
+
+**nzakas:** We're not planning on changing the algorithm, just the typing.
+
+**mdjermanovic:** I know but we should ensure that the typing holds
+
+**mdjermanovic:** For future changes
+
+**nzakas:** So are you saying we should add the tests now?
+
+**mdjermanovic:** Yes, to ensure passing `string|number|boolean|bigint|null|undefined` values will work as expected, if there are already no such tests
+
+**nzakas:** Okay, I read your comment as "if we ever change the interpolation algorithm then we should change the tests," but you mean, "we should add tests now to protect this behavior so if we ever change the interpolation algorithm we'll catch it."
+
+**nzakas:** Yes, let's add tests for the current behavior. 👍👍
+ * 👍 @mdjermanovic
+
+**mdjermanovic:** Yes, to catch possible regressions
+
+**fasttime:** That would be adding tests in `eslint` and updating the types in the rewrite repo.
+ * 👍 @nzakas, @mdjermanovic
+
+**nzakas:** Okay, next item:
+https://github.com/eslint/eslint/pull/20105
+
+**nzakas:** @fasttime this is you: https://github.com/eslint/eslint/pull/20105#discussion_r2352281406
+
+**fasttime:** So, RuleTester has some undocumented static methods: `setDefaultConfig`, `getDefaultConfig` and `resetDefaultConfig`.
+
+**fasttime:** These are all well-tested but it's not clear to me if those were ever used.
+
+**fasttime:** The question is whether we want to make those methods public by adding types and documentation (as they stand now, they are of no use).
+
+**nzakas:** setDefaultConfig usage: https://sourcegraph.com/search?q=context:global+repo:.*eslint.*plugin.*+setDefaultConfig&patternType=keyword&sm=0
+ * 👍 @fasttime
+
+**nzakas:** I think we should add types and docs.
+
+**fasttime:** Sounds good 👍
+
+**mdjermanovic:** Looks like these methods are used, so sounds good to me to add types and docs
+
+**nzakas:** Okay, we've agreed to add types and docs for these methods.
+ * 👍 @mdjermanovic, @fasttime
+
+**nzakas:** Next item:
+https://github.com/eslint/eslint/pull/19563
+
+**nzakas:** This one has been open for a long time. @fasttime :
+https://github.com/eslint/eslint/pull/19563#issuecomment-3308792275
+
+**fasttime:** Okay, let me try to resume the problem
+
+**fasttime:** The `@typescript-eslint/no-redeclare` rule is controversial. On one hand, it reports problems that TypeScript already catches; on the other, it flags types and values sharing the same name, which some developers consider unnecessary.
+
+**fasttime:** We want to decide how to update the `no-redeclare` rule to support TypeScript syntax. We have some options here:
+
+**fasttime:** 1. Report types and values with identical names, as `@typescript-eslint/no-redeclare` does, but without the bulk of options of the original rule (which are mostly used to report cases already covered by TypeScript).
+
+**fasttime:** 2. This was suggested by Kirk Waiblinger: adding an option to indicate whether values and types with the same name should be reported in cases where TypeScript allows them (e.g. function and interface).
+
+**fasttime:** 3. Diverge from the original rule and make our rule as permissive as possible.
+
+**fasttime:** I think 2. is a good compromise, but yes, that PR has been open for quite a while, I'd be happy to see this settled in any direction.
+
+**nzakas:** Option 2 seems like a pragmatic choice to me
+
+**mdjermanovic:** I'm not if types and values sharing the same name qualifies as redeclaration. The fact that `@typescript-eslint/plugin` has this check in their extension rule doesn't necessarily mean it belongs in this rule
+
+**mdjermanovic:** To me this check feels like a different rule
+
+**mdjermanovic:** As the type and the value declaration are not declaring the same thing, so it isn't quite a redeclaration?
+
+**fasttime:** That sounds like option 3., not reporting name conflicts across values and types.
+
+**fasttime:** I'm fine with either solution at this point.
+
+**nzakas:** I'm fine with option 3.
+
+**mdjermanovic:** I'm also fine with option 3.
+
+**nzakas:** Okay, we've agreed to go with option 3.
+ * 👍 @mdjermanovic, @fasttime
+
+**nzakas:** I think that's the last of the non-v10 issues?
+ * 👍 @mdjermanovic, @fasttime
+
+**nzakas:** Okay, next item:
+
+> Agenda item: Starting with ESLint v10.0.0-alpha.0, `@eslint/js` is no longer a direct dependency of `eslint`. Previously, we always released `@eslint/js` alongside `eslint` to keep their versions in sync. This seems no longer necessary now. Should we continue releasing `@eslint/js` together with `eslint`, even when there are no changes?
+
+**nzakas:** I think the synchronization only becomes an issue when rules are added to ensure the `recommended` and `all` configs stay in sync.
+
+**nzakas:** So it seems like we don't need to keep the version numbers in sync going forward.
+
+**mdjermanovic:** So, for example, if we add a new rule in ESLint v10.5.0, and update the `all` config, which version of `@eslint/js` would we release, v10.1.0?
+
+**nzakas:** Yes
+
+**mdjermanovic:** Then, we should probably add a peerDependency to eslint?
+
+**mdjermanovic:** As `@eslint/js` v10.1.0 won't work with ESLint < 10.5.0
+
+**mdjermanovic:** Or maybe bump the major version of `@eslint/js`, as adding new rules to a config is typically a breaking change
+
+**fasttime:** Makes sense I think. Eventually, when `@eslin/js` becomes a self-contained language plugin we'd want to release it independently.
+
+**nzakas:** Yes, that's the goal
+
+**nzakas:** Okay, it's getting late, let's try to move things along.
+
+**nzakas:** Do we agree that `@eslint/js` will only be released when there are changes and to add a peer dependency on ESLint?
+
+**fasttime:** Sounds good to me.
+
+**mdjermanovic:** Sounds good to me too.
+
+**nzakas:** Okay, it is so!
+
+**nzakas:** Next: https://github.com/eslint/js/issues/708
+
+**fasttime:** I just wanted to make sure we get this on the v10 board.
+
+**fasttime:** I opened a PR in DefinitelyTyped, don't know when it will be merged. In the mid-term, it would be good to add built-in types to `eslint-scope`.
+
+**nzakas:** Is there any reason not to just add types to `eslint-scope` and not deal with DefinitelyTyped?
+
+**fasttime:** Makes sense, yes. I could work on a PR next week.
+ * 👍 @nzakas, @mdjermanovic
+
+**nzakas:** Okay, we've agreed to add types to the `eslint-scope` package.
+ * 👍 @mdjermanovic, @fasttime
+
+**nzakas:** Next: https://github.com/eslint/eslint/pull/20125
+
+**nzakas:** > **TSC Summary**: This PR aims to disallow specifying `"errors"` and `"output"` properties on `valid` test case objects. The original issue, which has been accepted for ESLint v10.0.0, does not mention the `"output"` property and we didn't discuss it.
+> 
+> **TSC Question**: Do we want to include disallowing the `"output"` property on valid test case objects in ESLint v10.0.0?
+
+**nzakas:** Makes sense to me 👍
+
+**mdjermanovic:** I'm in favor, as it's similar to `errors`: a property that makes sense on `invalid` test objects only. We just haven't discussed it yet.
+
+**mdjermanovic:** Makes sense to me too
+
+**fasttime:** I'm also in favor.
+
+**nzakas:** Okay, we've agreed to also disallow `output` in valid test cases.
+ * 👍 @mdjermanovic, @fasttime
+
+**nzakas:** All right, that's everything on the agenda. Are there other things to discuss related to v10?
+
+**mdjermanovic:** I think there are only 3 things left for alpha.0:
+
+1. Check if the Node.js upgrade on Jenkins is correct.
+
+**mdjermanovic:** 2. Update and merge this as it was announced for alpha.0: https://github.com/eslint/eslint/pull/20086
+
+**mdjermanovic:** 3. Release eslint/rewrite packages and update deps to them in `eslint`
+
+**mdjermanovic:** (3. depends on 2.)
+
+**nzakas:** I'll get Node.js working on Jenkins and update that PR tomorrow morning
+ * 👍 @mdjermanovic
+
+**mdjermanovic:** Oh, and if you can check this: https://github.com/eslint/eslint/pull/20315
+ * 👍 @nzakas
+
+**mdjermanovic:** Alright, then I think we'll be good for v10.0.0-alpha.0 tomorrow
+ * 🎉 @fasttime
+
+**mdjermanovic:** I can do the release tomorrow
+ * 🙏 @nzakas, @fasttime
+
+**fasttime:** We should release eslint/rewrite timely so if any integration tests start breaking we can deactivate them.
+ * 👍 @mdjermanovic
+
+**mdjermanovic:** I can release eslint/rewrite and update deps in eslint/eslint right after `https://github.com/eslint/eslint/pull/20086` is merged
+
+**nzakas:** I think Jenkins should be set now
+
+**mdjermanovic:** Looks like, `node -v` is working for me now
+ * 🎉 @nzakas
+
+**nzakas:** We'll also need to update this page: https://eslint.org/version-support/
+
+**mdjermanovic:** To add v10.x now?
+
+**nzakas:** And update v9.x
+
+**nzakas:** v10.x -> Current
+v9.x -> Maintenance
+ * 👍 @mdjermanovic, @fasttime
+
+**nzakas:** Commerical Support would be Tidelift for both
+
+**mdjermanovic:** I can prepare a PR tomorrow
+ * 👍 @fasttime
+
+**mdjermanovic:** That should be merged after the release?
+
+**nzakas:** Yes
+
+**nzakas:** I'm sorry, I need to get going. For the record, we still need to do the contributor pool. We have $1071 funds for October:
+https://github.com/eslint/tsc-meetings/blob/main/notes/2025/2025-11-01-contributor-pool.md
+ * 👍 @mdjermanovic, @fasttime
+
+**nzakas:** If you want to do it without me, please feel free, otherwise we can review next meeting.
+
+**mdjermanovic:** Let's leave it for the next meeting
+ * 👍 @fasttime
+
+**fasttime:** Yes, it's late today.
+
+**nzakas:** Just a reminder: I won't be at the next meeting due to US Thanksgiving holiday.
+ * 👍 @mdjermanovic, @fasttime
+
+**nzakas:** All right, thanks everyone ! (And thanks @sam3k_ for the notes)
+
+**mdjermanovic:** Thanks 👋
+
+**fasttime:** Thanks! Bye 👋

--- a/notes/2026/2026-04-16-transcript.md
+++ b/notes/2026/2026-04-16-transcript.md
@@ -1,0 +1,79 @@
+# 04/16/2026 ESLint TSC Meeting Transcript
+
+**nzakas:** Howdy!
+
+**fasttime:** Hi!
+
+**nzakas:** Looks like we are having trouble getting to full strength here. Feel better @mdjermanovic
+ * 👍 @fasttime
+
+**nzakas:** Let me pull up last meeting's notes
+
+**nzakas:** Okay, looks like nothing to review.
+
+**fasttime:** No, nothing I think.
+
+**nzakas:** Then let's start with statuses.
+
+I've been pretty sick so haven't done much outside of triaging issues and PRs as I've been able.
+
+**fasttime:** I wasn't sick, but I had some unexpected setbacks, so I also haven't done much, only reviews and some maintenance PRs.
+
+**nzakas:** Seems to be that time of year. 🙂
+ * 🤷 @fasttime
+
+**nzakas:** Let's talk availability the next couple of weeks. 
+
+I'm trying to do 0.5 hours per weekday, pending my health stabilizing. 🤞
+ * 🤞 @fasttime
+
+**fasttime:** I should be able to work 10-12 hours per week the next two weeks.
+
+**nzakas:** RFC Duty:
+This week: @nzakas 
+April 20: @fasttime 
+April 27: @mdjermanovic
+ * 👍 @fasttime
+
+**nzakas:** It looks like we don't have anything flagged for today. Is there anything you'd like to discuss?
+
+**fasttime:** Nothing specifically from my side.
+
+**nzakas:** Do we want to discuss this? https://github.com/eslint/eslint/pull/20716
+
+**nzakas:** The `meta.languages` question
+
+**nzakas:** The question is if implementing this on core rules is a breaking change.
+
+Also, should we go ahead and update the `json`, `css`, and `markdown` plugins first.
+
+**nzakas:** I added a comment that I do think it's a breaking change and we should be very deliberate in how we update core rules with this info.
+
+**fasttime:** I'm also under the impression that this change in the core rules would break a few setups. I'd be in favor of updating  the language plugins first.
+
+**nzakas:** Okay, we've decided to hold off on updating the cores rules with `meta.languages`. We'll instead work on adding this info to the language plugins to see how they work in the wild.
+
+**fasttime:** For the core rules, we could add `meta.docs.dialects`, but with `meta.languages` it seems better to hold off.
+
+**nzakas:** Yeah, we can do that. At least that way we'll know which rules have already been updated to support TypeScript.
+ * 👍 @fasttime
+
+**nzakas:** That's all I had. Shall we discuss the release?
+
+**fasttime:** I can do the release tomorrow.
+
+**nzakas:** Thanks 🙏
+ * 😀 @fasttime
+
+**fasttime:** I don't see any features since the previous release, so that would be a patch release.
+
+**nzakas:** Sounds good. Should be an easy one.
+
+**fasttime:** Hopefully so. Also no packages to release other than `eslint`.
+
+**nzakas:** Looks like we have a new `config-inspector` release ready, I'll just go do that now.
+ * 👍 @fasttime
+
+**nzakas:** I think that's it for today. Thanks! (And thanks @sam3k_ for the notes)
+
+**fasttime:** Thanks! Bye 👋

--- a/notes/2026/2026-05-14-transcript.md
+++ b/notes/2026/2026-05-14-transcript.md
@@ -1,0 +1,107 @@
+# 05/14/2026 ESLint TSC Meeting Transcript
+
+**mdjermanovic:** Hi!
+
+**fasttime:** Hi 👋
+
+**nzakas:** Howdy
+
+**nzakas:** Going to pull up the notes from last time...
+
+**nzakas:** Looks like we didn't have anything to review from last time so let's just right into statuses.
+
+Unfortunately, my health still prevented me from doing too much other than trying to check in on some issues and PRs.
+
+**mdjermanovic:** I was reviewing PRs, working on file-entry-cache upgrade, and prepared v9.x EOL notices.
+
+**fasttime:** I was mostly busy reviewing PRs this time.
+
+**nzakas:** Availability the next two weeks: I expect my availability to remain unchanged until my health improves.
+
+**mdjermanovic:** I expect to be able to work 1-1.5h per day
+
+**fasttime:** I should be able to work 10-12 hours per week the next two weeks
+
+**nzakas:** RFC Duty:
+This week - @fasttime 
+May 18 - @mdjermanovic 
+May 25 - @nzakas
+ * 👍 @mdjermanovic, @fasttime
+
+**nzakas:** Looks like we have one issue flagged for today.
+
+https://github.com/eslint/code-explorer/issues/378
+
+**nzakas:** > **TSC Summary**:
+>     * Node.js 20 reached End-of-Life on April 30, 2026, but web apps such as `code-explorer` and `eslint.org` are still depending on it.
+> 
+> **TSC Question**:
+>     * Which Node.js version would be best to update to? Should we move directly to version 24 or take it one step at a time with version 22?
+>     * Also, what would be the recommended first step for this transition, especially since some parts of the setup might require setup changes on Netlify?
+
+**mdjermanovic:** I think we should switch to Node.js 24
+ * 👍 @nzakas, @fasttime
+
+**mdjermanovic:** As for the the steps, not sure yet as some sites have local configs, but we can figure that out
+
+**nzakas:** Okay, we've agreed to upgrade Netlify apps to Node.js 24. Technical details to be determined on a per-app basis.
+ * 👍 @mdjermanovic, @fasttime
+
+**nzakas:** We do have one `tsc waiting` PR:
+https://github.com/eslint/eslint/pull/20396
+
+**nzakas:** This was to remove dependency on the `Intl` global, but it seems that's trickier than we first thought. I'm in favor of not moving forward with this PR.
+
+**mdjermanovic:** Seems that we all agree to keep using `Intl` and just update prerequisites
+
+**fasttime:** Yes, just update the docs
+
+**nzakas:** Okay, we've agreed not to move forward with this PR and instead to update the documented prerequisites for running ESLint.
+
+Do we want to close this PR?
+
+**mdjermanovic:** I think yes
+ * 👍 @nzakas, @fasttime
+
+**nzakas:** Okay I'll do that now.
+
+**nzakas:** All right, any other issues or PRs anyone would like to discuss? Or topics in general?
+
+**mdjermanovic:** Nothing in particular from my side for today
+
+**fasttime:** Nothing from my side either
+
+**nzakas:** All right, let's take a look at the contributor pool. We have a budget of $762 for the month:
+https://github.com/eslint/tsc-meetings/blob/main/notes/2026/2026-05-01-contributor-pool.md
+
+**nzakas:** I've not been around enough to tell how much work these were, so I'll defer to you two for suggested amounts
+
+**fasttime:** Shall we award all PRs the same amount? I don't see any particularly big or small PRs that would stand out
+
+**nzakas:** We could do sethamus $500 and xbinaryx $200?
+ * 👍 @fasttime
+
+**mdjermanovic:** Sounds good to me
+
+**nzakas:** Okay, I'll let them know.
+ * 👍 @mdjermanovic
+
+**fasttime:** Thanks!
+
+**nzakas:** Let's talk about the release
+
+**mdjermanovic:** I can tomorrow
+ * 🙏 @nzakas
+
+**fasttime:** Thanks!
+
+**mdjermanovic:** eslint/rewrite deps updates have been already released and integrated in eslint, so I think it would be just the `eslint` package this time.
+ * 👍 @nzakas, @fasttime
+
+**mdjermanovic:** Okay, then just `eslint` for tomorrow
+
+**nzakas:** All right, then I think we're all done for today. Thanks everyone (and thanks @sam3k_ for the notes)
+
+**mdjermanovic:** Thanks 👋
+
+**fasttime:** Thanks 👋 bye!


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### AI acknowledgment

- [x] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request?

Adds missing meeting transcripts for 2025-10-02, 2025-11-13, 2026-04-16, 2026-05-14.

#### What changes did you make? (Give an overview)

Set corresponding values as ISSUE_TITLE env variable and ran `npm run generate:transcript`.

Alternatively, we could re-run jobs but that doesn't seem available for some of these (probably due to the age), or reopen-close issues but that would generate new issues for past meetings.

#### Related Issues

https://github.com/eslint/tsc-meetings/pull/710 fixed empty transcripts like https://github.com/eslint/tsc-meetings/pull/709.

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?
