### PR TITLE
docs: Add 2026-07-09 and 2026-07-23 meeting notes

### DIFF
--- a/notes/2026/2026-07-09.md
+++ b/notes/2026/2026-07-09.md
@@ -1,0 +1,99 @@
+# 2026-07-09 ESLint TSC Meeting Notes
+
+## Transcript
+
+[`2026-07-09-transcript.md`](2026-07-09-transcript.md)
+
+## Attending
+
+- Nicholas C. Zakas (@nzakas) - TSC
+- Milos Djermanovic (@mdjermanovic) - TSC
+- Francesco Trotta (@fasttime) - TSC
+
+@nzakas moderated. Notes compiled by @sam3k from the transcript after the fact.
+
+## Topics
+
+### Follow-up from Previous Meeting
+
+**TSC Summary:** @mdjermanovic confirmed the SemVer policy update from the previous meeting is complete.
+
+### Statuses
+
+* **@nzakas:** Focused mostly on sponsorship outreach: Shopify is returning and CodeRabbit is a new sponsor. Still dealing with health issues, limited time otherwise.
+* **@mdjermanovic:** Worked on the file-entry-cache upgrade, fixed a problem with v9.x-dev CI, and was reviewing PRs and triaging issues.
+* **@fasttime:** Mostly busy with reviewing issues and PRs.
+
+### Availability Next Two Weeks
+
+* **@nzakas:** Expects availability to remain unchanged, in the range of 0.5-1.5 hours per week.
+* **@mdjermanovic:** Offline the next 3 days, then expects 1-1.5h daily, with some days offline.
+* **@fasttime:** About 10 hours next week, and a bit less (maybe 7 hours) the week after.
+
+### RFC Duty Update
+
+* This week: @nzakas
+* July 13: @fasttime
+* July 20: @mdjermanovic
+
+### [Change Request: Backport require.cache guard fix (#20812) to the ESLint 9.x maintenance line](https://github.com/eslint/eslint/issues/21060)
+
+**TSC Summary:** @fasttime flagged an issue requesting a backport of a fix already released in v10.x. A PR is already open. The question for the TSC was whether to accept the backport (which would imply a v9.x patch release).
+
+**Discussion Points:**
+- @fasttime confirmed he'd be fine with the backport but wanted the TSC aligned first.
+- @nzakas noted that since it's already fixed in v10.x, backporting makes sense.
+- @mdjermanovic agreed.
+- @fasttime offered to review and merge the PR after the meeting.
+
+**Resolution:** The TSC accepted the issue and agreed to port the fix to the v9.x line.
+
+### [Change Request: Export file globs of supported files](https://github.com/eslint/eslint/issues/20590)
+
+**TSC Summary:** The issue seeks consensus on exporting common glob patterns for supported files (e.g. `**/*.{mjs,cjs,js,jsx,mts,cts,ts,tsx}` for JavaScript). The TSC question was whether to seek consensus on the approach or require an RFC.
+
+**Discussion Points:**
+- @mdjermanovic recalled that this was discussed in a previous meeting.
+- @nzakas checked the notes and confirmed it was covered on 2026-06-11 (the meeting @sam3k missed and for which no summary exists), pointing to the transcript for the recorded outcome.
+
+**Resolution:** No new decision; @nzakas will update the issue with the note from the 2026-06-11 discussion.
+
+### [Change Request: publish official docker image](https://github.com/eslint/eslint/issues/20430) ([RFC #140](https://github.com/eslint/rfcs/pull/140))
+
+**TSC Summary:** This issue seeks consensus on publishing an official Docker image for ESLint. It has been open for roughly six months without definitive consensus. The TSC question was whether to accept and proceed through the ongoing RFC.
+
+**Discussion Points:**
+- @nzakas was 👎; he didn't see the value.
+- @mdjermanovic agreed, citing the earlier discussion around plugins.
+- @fasttime was also opposed, noting it would be a lot of maintenance work for plugins the team doesn't maintain.
+
+**Resolution:** The TSC agreed not to accept the issue.
+
+### Blog Post Review
+
+**TSC Summary:** @nzakas will review Alex's blog post and schedule it for publication (carried over from the meeting agenda issue).
+
+### Contributor Pool for July 2026
+
+**TSC Summary:** The team reviewed the [July contributor pool](https://github.com/eslint/tsc-meetings/blob/main/notes/2026/2026-07-01-contributor-pool.md), with a budget of $907.70 for the month.
+
+**Discussion Points:**
+- @mdjermanovic and @fasttime noted that two of the listed contributors (including navi2-dil) have had their accounts deleted along with their PRs and issues.
+- @nzakas added that pierluigilenoci has also disappeared; a "strange month," in his words.
+- @nzakas observed that many of the remaining contributions were small, and that the CI PRs might not qualify.
+- @fasttime confirmed the CI PRs were small.
+- @nzakas proposed $150 for kirkwaiblinger and $100 for sethamus, which @mdjermanovic and @fasttime agreed to.
+
+**Resolution:** The TSC agreed to award kirkwaiblinger $150 and sethamus $100.
+
+**Action Items:**
+- @nzakas will notify the contributors.
+
+### Scheduled Release for July 10th, 2026
+
+**Packages to Release:**
+- `eslint`
+- v9.x maintenance release
+
+**Action Items:**
+- @fasttime will do both releases on July 10th.

--- a/notes/2026/2026-07-09.md
+++ b/notes/2026/2026-07-09.md
@@ -73,9 +73,9 @@
 
 **TSC Summary:** @nzakas will review Alex's blog post and schedule it for publication (carried over from the meeting agenda issue).
 
-### Contributor Pool for July 2026
+### Contributor Pool for June 2026
 
-**TSC Summary:** The team reviewed the [July contributor pool](https://github.com/eslint/tsc-meetings/blob/main/notes/2026/2026-07-01-contributor-pool.md), with a budget of $907.70 for the month.
+**TSC Summary:** The team reviewed the [June contributor pool](https://github.com/eslint/tsc-meetings/blob/main/notes/2026/2026-07-01-contributor-pool.md), with a budget of $907.70 for the month.
 
 **Discussion Points:**
 - @mdjermanovic and @fasttime noted that two of the listed contributors (including navi2-dil) have had their accounts deleted along with their PRs and issues.

--- a/notes/2026/2026-07-23.md
+++ b/notes/2026/2026-07-23.md
@@ -1,0 +1,58 @@
+# 2026-07-23 ESLint TSC Meeting Notes
+
+## Transcript
+
+[`2026-07-23-transcript.md`](2026-07-23-transcript.md)
+
+## Attending
+
+- Nicholas C. Zakas (@nzakas) - TSC
+- Milos Djermanovic (@mdjermanovic) - TSC
+- Francesco Trotta (@fasttime) - TSC
+
+@nzakas moderated. Notes compiled by @sam3k from the transcript after the fact.
+
+## Topics
+
+### Follow-up from Previous Meeting
+
+**TSC Summary:** No formal follow-up items. @nzakas noted that the notes for the previous meeting (2026-07-09) had not yet been written. @mdjermanovic pointed out that closing the meeting issue will generate the transcript.
+
+### Statuses
+
+* **@nzakas:** Still mostly away due to health issues. The time available went to reviewing and publishing the Codemod announcement and docs.
+* **@mdjermanovic:** Mostly reviewing PRs and triaging issues.
+* **@fasttime:** Fixed two bugs in the main repo and updated the architecture documentation. Otherwise, reviewing issues and PRs.
+
+### Availability Next Two Weeks
+
+* **@nzakas:** Expects to stay at around 0.5-1.5 hours per week.
+* **@mdjermanovic:** Around 7 hours per week; offline August 2-4.
+* **@fasttime:** Around 7 hours per week for the next two weeks.
+
+### RFC Duty Update
+
+* This week: @mdjermanovic
+* July 27: @nzakas
+* August 3: @fasttime
+
+### Triage Board Reminder
+
+**TSC Summary:** @nzakas noted that a number of items have been sitting in the "needs triage" column of the Triage board for several weeks and asked the team to check the board regularly.
+
+**Discussion Points:**
+- @fasttime suggested asking other team members to help.
+- @nzakas agreed that triage is everyone's responsibility.
+
+**Resolution:** @nzakas will send out an email reminder to the team.
+
+**Action Items:**
+- @nzakas will email the team about checking the Triage board.
+
+### Scheduled Release for July 24th, 2026
+
+**Packages to Release:**
+- `eslint` (`config-helpers` was already released, so nothing else this cycle).
+
+**Action Items:**
+- @fasttime will do the release on July 24th.


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### AI acknowledgment

- [x] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request?

Adding missing notes for past two TSC meetings.

#### What changes did you make? (Give an overview)

Add notes for 2026-07-09 and 2026-07-23 TSC meetings. 

#### Related Issues

Closes #735 
<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?
