### PR TITLE
docs: Add meeting notes and meeting notes skill

### DIFF
--- a/.github/skills/meeting-notes-generator/SKILL.md
+++ b/.github/skills/meeting-notes-generator/SKILL.md
@@ -24,6 +24,15 @@ following the exact structure and conventions below. If the transcript isn't
 already saved as `notes/<year>/<YYYY-MM-DD>-transcript.md`, save it there first
 (verbatim, unedited) before writing the notes file.
 
+**Summary-only requests are different from note-generation requests.** If the
+user only asks for a spoken/chat summary of a transcript (not a notes file),
+do not write or modify any files in `notes/` — just reply with the summary
+directly in the conversation. Only save the verbatim transcript and write the
+`notes/<year>/<YYYY-MM-DD>.md` file when the user is explicitly asking for
+meeting notes to be generated (per this skill's contract). This avoids
+unintentionally committing unedited, pasted transcript text to the repository
+when the user only wanted a quick summary.
+
 ## Step-by-step process
 
 1. **Determine the date and year** from the transcript filename or its first
@@ -37,13 +46,19 @@ already saved as `notes/<year>/<YYYY-MM-DD>-transcript.md`, save it there first
    found in prior notes, use just `@handle` and flag it for the user to
    confirm rather than guessing a full name.
 
-3. **Identify who moderated and who took notes.** This is usually stated
-   explicitly near the top of the transcript (e.g., "can you take notes?" /
-   "yep") or implied by who is driving the agenda (moderator is almost always
-   @nzakas unless the transcript says otherwise). If a third person is
-   mentioned taking notes without attending/speaking (e.g., "(Thanks
-   @sam3k_ for the notes.)"), do NOT list them under "Attending" — instead
-   attribute note-taking to them in the sentence below the attendee list.
+3. **Identify who moderated and who took notes.** Only attribute the
+   moderator role based on explicit evidence in the transcript — e.g., someone
+   asking "can you take notes?", visibly driving the agenda (asking the
+   opening/status questions, introducing each topic, calling for
+   resolutions), or an explicit statement of who's moderating. Do not default
+   to attributing moderation to any particular person (including @nzakas)
+   just because they're a frequent moderator in past meetings. If the
+   transcript is genuinely ambiguous about who moderated, omit the
+   moderator attribution sentence entirely (or ask the user to confirm)
+   rather than guessing. If a third person is mentioned taking notes without
+   attending/speaking (e.g., "(Thanks @sam3k_ for the notes.)"), do NOT list
+   them under "Attending" — instead attribute note-taking to them in the
+   sentence below the attendee list.
 
 4. **Note absences.** If the transcript explicitly says a known TSC member is
    absent (e.g., "@nzakas is absent so it'll just be us today"), add a line:
@@ -62,9 +77,12 @@ already saved as `notes/<year>/<YYYY-MM-DD>-transcript.md`, save it there first
 
    Give each topic section a heading (`###`) using a short descriptive title.
    If the topic centers on a specific GitHub issue/PR, link its title:
-   `### [Issue or PR title](https://github.com/.../issues/123)`. Reuse the
-   actual issue/PR title from GitHub if the transcript link only shows a URL
-   (fetch the page or infer from context if not obtainable).
+   `### [Issue or PR title](https://github.com/.../issues/123)`. Use the
+   actual issue/PR title from GitHub (fetch the page to confirm it) whenever
+   possible. Never invent or infer a plausible-sounding title — if the title
+   can't be confirmed (e.g., GitHub is unreachable), use a neutral heading
+   that includes the raw URL instead (e.g., `### Discussion: <url>`), or ask
+   the user to confirm the correct title before using it.
 
 6. **Write each topic section** using these conventions:
    - Summarize the discussion in third person as concise bullet points or
@@ -85,7 +103,7 @@ already saved as `notes/<year>/<YYYY-MM-DD>-transcript.md`, save it there first
      notes.
    - If a topic produces concrete follow-up work, add an
      `**Action Items:**` bullet list grouped by owner handle, e.g.:
-     ```
+     ```markdown
      **Action Items:**
      - @handle will:
        - Do the release
@@ -142,7 +160,7 @@ already saved as `notes/<year>/<YYYY-MM-DD>-transcript.md`, save it there first
 8. **Verify before finishing:**
    - Every attendee in the transcript's speaker list appears in "Attending"
      (or is explicitly credited as note-taker/absent, not silently dropped).
-   - Every `### ` topic maps to a real, distinct portion of the transcript —
+   - Every `###` topic maps to a real, distinct portion of the transcript —
      don't invent topics that weren't discussed.
    - All GitHub links from the transcript appear somewhere in the notes.
    - Run a quick diff-read against 2-3 existing notes files (e.g.

--- a/.github/skills/meeting-notes-generator/SKILL.md
+++ b/.github/skills/meeting-notes-generator/SKILL.md
@@ -73,6 +73,9 @@ when the user only wanted a quick summary.
    - Specific issues/PRs discussed (one topic section per issue/PR, usually
      introduced via a linked GitHub URL)
    - Scheduling topics (meeting cadence, holidays, RFC duty rotation)
+   - Contributor pool (recurring topic in the first meeting of a month; see
+     the naming note under step 7 below — it's easy to get the covered month
+     wrong)
    - The scheduled release for that cycle (almost always the last topic)
 
    Give each topic section a heading (`###`) using a short descriptive title.
@@ -156,6 +159,17 @@ when the user only wanted a quick summary.
      bullet style and match it.
    - Always end with the scheduled-release topic if the transcript discusses
      one, since this matches the established pattern.
+   - The contributor pool topic is named after the month the linked
+     `notes/<year>/<YYYY-MM-01>-contributor-pool.md` report *covers*, not the
+     month the meeting takes place in. Since this report is generated on the
+     1st of the month and typically discussed in that month's first TSC
+     meeting, it always covers the *previous* calendar month (e.g., a report
+     linked as `2026-06-01-contributor-pool.md` and discussed at the June 11
+     meeting covers May 2026 activity, so the heading should read
+     `### Contributor Pool for May 2026`). Open the linked report and check
+     its date range in the title (e.g., `(05/01/2026 - 05/31/2026)`) to
+     confirm the correct month before naming this heading — it's easy to get
+     wrong.
 
 8. **Verify before finishing:**
    - Every attendee in the transcript's speaker list appears in "Attending"

--- a/.github/skills/meeting-notes-generator/SKILL.md
+++ b/.github/skills/meeting-notes-generator/SKILL.md
@@ -1,0 +1,157 @@
+---
+name: meeting-notes-generator
+description: Generates ESLint TSC meeting notes from a raw meeting transcript, following the conventions used in this repository's notes/ directory. Use this when asked to write, create, or generate meeting notes from a transcript, or to summarize an ESLint TSC meeting.
+license: MIT
+---
+
+# ESLint TSC Meeting Notes Generator
+
+This skill turns a raw chat-style meeting transcript into a polished meeting
+notes file, matching the style used throughout `notes/<year>/`.
+
+## Inputs
+
+- A transcript, either:
+  - An existing file already saved as `notes/<year>/<YYYY-MM-DD>-transcript.md`, or
+  - Raw transcript text/paste provided directly in the conversation.
+- The meeting date (infer from the transcript filename or content, or ask the
+  user if it truly cannot be determined).
+
+## Output
+
+A file at `notes/<year>/<YYYY-MM-DD>.md` (same date/year as the transcript),
+following the exact structure and conventions below. If the transcript isn't
+already saved as `notes/<year>/<YYYY-MM-DD>-transcript.md`, save it there first
+(verbatim, unedited) before writing the notes file.
+
+## Step-by-step process
+
+1. **Determine the date and year** from the transcript filename or its first
+   line (e.g., `# 12/11/2025 ESLint TSC Meeting Transcript`). The notes file
+   uses ISO format: `YYYY-MM-DD.md`, saved under `notes/<YYYY>/`.
+
+2. **Identify attendees.** Scan every speaker handle (`**handle:**`) in the
+   transcript. Cross-reference past notes files (`grep` other files in
+   `notes/`) to find each person's full display name — the "Attending" list
+   always uses the pattern `Full Name (@handle) - TSC`. If a name can't be
+   found in prior notes, use just `@handle` and flag it for the user to
+   confirm rather than guessing a full name.
+
+3. **Identify who moderated and who took notes.** This is usually stated
+   explicitly near the top of the transcript (e.g., "can you take notes?" /
+   "yep") or implied by who is driving the agenda (moderator is almost always
+   @nzakas unless the transcript says otherwise). If a third person is
+   mentioned taking notes without attending/speaking (e.g., "(Thanks
+   @sam3k_ for the notes.)"), do NOT list them under "Attending" — instead
+   attribute note-taking to them in the sentence below the attendee list.
+
+4. **Note absences.** If the transcript explicitly says a known TSC member is
+   absent (e.g., "@nzakas is absent so it'll just be us today"), add a line:
+   `**Note:** Full Name (@handle) was absent.` below the moderator/notes
+   sentence. Do not invent absences — only note them if stated.
+
+5. **Segment the transcript into topics.** Read through the whole transcript
+   and split it into logical discussion topics in chronological order. Common
+   recurring topics, in typical order, include:
+   - Statuses / availability updates
+   - Follow-ups from previous meeting notes
+   - Specific issues/PRs discussed (one topic section per issue/PR, usually
+     introduced via a linked GitHub URL)
+   - Scheduling topics (meeting cadence, holidays, RFC duty rotation)
+   - The scheduled release for that cycle (almost always the last topic)
+
+   Give each topic section a heading (`###`) using a short descriptive title.
+   If the topic centers on a specific GitHub issue/PR, link its title:
+   `### [Issue or PR title](https://github.com/.../issues/123)`. Reuse the
+   actual issue/PR title from GitHub if the transcript link only shows a URL
+   (fetch the page or infer from context if not obtainable).
+
+6. **Write each topic section** using these conventions:
+   - Summarize the discussion in third person as concise bullet points or
+     short prose attributed to each speaker, e.g.
+     `* **@handle:** Has been mostly reviewing PRs...` or
+     `* @handle thinks X, @otherhandle disagrees because Y.`
+   - Preserve technical details, links, and numbers exactly as stated (dates,
+     version numbers, PR/issue links) — do not paraphrase facts loosely.
+   - When the transcript shows the group converging on a decision, add a
+     `**Resolution:** ...` line (bold, on its own paragraph) summarizing what
+     was decided and who is responsible for follow-up.
+   - For longer/more nuanced discussions, you may add a
+     `**TSC Summary:** ...` paragraph before the resolution, paraphrasing the
+     core question/context in neutral third person (see
+     `notes/2025/2025-12-11.md` for an example of this pattern).
+   - Reaction emoji (e.g., `👍 @handle`) in the transcript signal agreement —
+     use them as evidence of consensus but do not copy the raw emoji into the
+     notes.
+   - If a topic produces concrete follow-up work, add an
+     `**Action Items:**` bullet list grouped by owner handle, e.g.:
+     ```
+     **Action Items:**
+     - @handle will:
+       - Do the release
+       - Open an issue for X
+     ```
+   - Do not include small talk, greetings, or off-topic banter in the notes.
+
+7. **Assemble the final file** in this exact structure:
+
+   ```markdown
+   # <YYYY-MM-DD> ESLint TSC Meeting Notes
+
+   ## Transcript
+
+   [`<YYYY-MM-DD>-transcript.md`](<YYYY-MM-DD>-transcript.md)
+
+   ## Attending
+
+   - Full Name (@handle) - TSC
+   - Full Name (@handle) - TSC
+
+   @moderator moderated.
+
+   **Note:** Full Name (@handle) was absent.
+
+   ## Topics
+
+   ### Topic Title
+
+   ...discussion...
+
+   **Resolution:** ...
+
+   ### [Linked Issue/PR Title](url)
+
+   ...discussion...
+
+   **Resolution:** ...
+
+   ### Scheduled release for <Month Day>, <Year>
+
+   ...
+
+   **Resolution:** ...
+   ```
+
+   Notes:
+   - The "Attending" list may use either `-` or `*` bullets — check the most
+     recent existing notes file in the same year for the currently preferred
+     bullet style and match it.
+   - Always end with the scheduled-release topic if the transcript discusses
+     one, since this matches the established pattern.
+
+8. **Verify before finishing:**
+   - Every attendee in the transcript's speaker list appears in "Attending"
+     (or is explicitly credited as note-taker/absent, not silently dropped).
+   - Every `### ` topic maps to a real, distinct portion of the transcript —
+     don't invent topics that weren't discussed.
+   - All GitHub links from the transcript appear somewhere in the notes.
+   - Run a quick diff-read against 2-3 existing notes files (e.g.
+     `notes/2025/2025-12-11.md`, `notes/2023/2023-01-12.md`) to confirm
+     formatting/tone consistency before presenting the final file to the
+     user.
+
+## Example reference files
+
+Use these as the canonical style reference when generating new notes:
+- `notes/2025/2025-12-11-transcript.md` / `notes/2025/2025-12-11.md`
+- `notes/2023/2023-01-12-transcript.md` / `notes/2023/2023-01-12.md`

--- a/notes/2026/2026-06-11.md
+++ b/notes/2026/2026-06-11.md
@@ -20,7 +20,7 @@
 
 ### Statuses
 
-* **@nzakas:** Wasn't able to do much in the past two weeks due to ongoing health stuff.
+* **@nzakas:** Had limited availability.
 * **@mdjermanovic:** Was mostly reviewing PRs. Also fixed a bug in the ESLint Playground, and located the problem with empty TSC meeting transcripts and committed the missing ones.
 * **@fasttime:** Was mostly busy reviewing issues and pull requests, and opened issues to improve the ecosystem tests.
 

--- a/notes/2026/2026-06-11.md
+++ b/notes/2026/2026-06-11.md
@@ -1,0 +1,110 @@
+# 2026-06-11 ESLint TSC Meeting Notes
+
+## Transcript
+
+[`2026-06-11-transcript.md`](2026-06-11-transcript.md)
+
+## Attending
+
+- Nicholas C. Zakas (@nzakas) - TSC
+- Milos Djermanovic (@mdjermanovic) - TSC
+- Francesco Trotta (@fasttime) - TSC
+
+@nzakas moderated.
+
+## Topics
+
+### Follow-up from Previous Meeting
+
+**TSC Summary:** No follow-up items to review from the previous meeting.
+
+### Statuses
+
+* **@nzakas:** Wasn't able to do much in the past two weeks due to ongoing health stuff.
+* **@mdjermanovic:** Was mostly reviewing PRs. Also fixed a bug in the ESLint Playground, and located the problem with empty TSC meeting transcripts and committed the missing ones.
+* **@fasttime:** Was mostly busy reviewing issues and pull requests, and opened issues to improve the ecosystem tests.
+
+### Availability Next Two Weeks
+
+* **@nzakas:** Will try to be online a bit more, probably around 1-1.5 hours during each week, depending on how he's feeling.
+* **@mdjermanovic:** Expects to be available 1-1.5 hours per day.
+* **@fasttime:** Will be available 1 hour Mo-Fr and more on weekends, so maybe 10-12 hours per week.
+
+**RFC Duty:**
+- This week: @mdjermanovic
+- June 15: @nzakas
+- June 22: @fasttime
+
+### [Migrate `@eslint/migrate-config` to use `includeIgnoreFile`](https://github.com/eslint/rewrite/pull/457)
+
+**TSC Summary:** This PR is mainly about the future of the `@eslint/migrate-config` package, since `@eslint/v8-to-v9-config`, which has been verified in [eslint/eslint#20442](https://github.com/eslint/eslint/issues/20442) and is ready for a blog announcement, could replace it. This PR also changes the implementation to use `includeIgnoreFile` from the `eslint/config` subpath import. Since this feature was added in ESLint v10.4.0, it would break the existing v8-to-v9 migration tooling if merged as-is, so the change would need to be added in the next major version of `@eslint/migrate-config` instead, so it doesn't break the current migration solution.
+
+**Discussion Points:**
+- @mdjermanovic asked whether `migrate-config` should be deprecated in the near future; @nzakas felt it's too early to know, so the group agreed it should not be considered a frozen package.
+- @nzakas raised whether `migrate-config` should always migrate people to the latest ESLint version, since there's little reason to migrate to v9 if v10 is available.
+- @mdjermanovic noted this could be a problem for users on plugins that don't support v10 yet, though this is likely a rare case.
+- The group agreed to add a `--target-version` option, defaulting to `10`, with `9` available as an explicit opt-out.
+- @mdjermanovic pointed out that since the new default output (v10) could produce configs that don't work with v9, this should be considered a breaking change.
+
+**Resolution:** The TSC agreed that:
+- `migrate-config` will not be frozen or deprecated at this time.
+- The PR will be updated to support a `--target-version` option (default `10`, with `9` as an opt-out).
+- This change will be released as a breaking change.
+
+### [Widen rule `create()` types for ESLint v9 compatibility](https://github.com/eslint/markdown/pull/648)
+
+**TSC Summary:** This PR seeks consensus on the current approach to mitigating type compatibility issues with ESLint v9.x for the Markdown, JSON, and CSS language plugins, as mentioned in [eslint/json#213](https://github.com/eslint/json/issues/213). The PR includes only typing changes and no runtime behavior changes.
+
+**Discussion Points:**
+- @fasttime explained that a rule's `context` type changed in v10, making it difficult to create plugins that work with both ESLint v9 and v10.
+- The proposed solution types each rule's `create()` context as `unknown` and its return type as `any` in the built file only (not the source), bypassing TypeScript checks. This is acceptable as long as `create()` is only invoked by ESLint and not by TypeScript-aware tooling.
+- @nzakas and @fasttime both noted they'd like to remove this workaround at some point, possibly after v11.
+- @mdjermanovic agreed with the solution.
+
+**Resolution:** The TSC agreed to use this approach for now for the Markdown, JSON, and CSS language plugins, with the intention of removing it after v11. [eslint/json#213](https://github.com/eslint/json/issues/213) and this PR are accepted.
+
+### [Export common glob patterns from language plugins](https://github.com/eslint/eslint/issues/20590)
+
+**TSC Summary:** This issue seeks consensus on exporting common glob patterns for certain languages, such as `**/*.{mjs,cjs,js,jsx,mts,cts,ts,tsx}` for JavaScript. There is currently no definitive consensus on the design of the glob patterns, where to place them, or how to treat them across language plugins.
+
+**Discussion Points:**
+- @nzakas is not in favor of adding this to core, but sees merit in it as part of language plugins (e.g., `@eslint/js` exporting JS-related globs, `@eslint/markdown` exporting Markdown-related globs, etc.).
+
+**Resolution:** The TSC agreed not to add this to core, and will accept an RFC for extending language plugins with this information.
+
+### [Environment variable to set formatter name](https://github.com/eslint/eslint/issues/20946)
+
+**TSC Summary:** This "TSC waiting" issue asks for an environment variable to set the formatter name.
+
+**Discussion Points:**
+- @nzakas and @fasttime both noted this can already be achieved by parameterizing the CLI command (e.g., via a small shell script that reads the environment variable and runs ESLint).
+- @mdjermanovic was initially in favor, but agreed it's fine to close the issue since other ways of achieving the same result already exist.
+
+**Resolution:** The TSC agreed not to accept this proposal, as there are other ways of achieving the same thing.
+
+### Donations Update
+
+**TSC Summary:** @nzakas noted that donations are currently down to $7,699.08/month, the lowest level in a long time. He has reached out to some lapsed sponsors and isn't sure what else can be done, but wanted to flag this in case levels continue to drop.
+
+### Contributor Pool for June 2026
+
+**TSC Summary:** The team reviewed the [June contributor pool](https://github.com/eslint/tsc-meetings/blob/main/notes/2026/2026-06-01-contributor-pool.md), with a budget of $741.50 for the month.
+
+**Discussion Points:**
+- @mdjermanovic proposed $250 for each of the three contributors, as the effort looked about the same, putting the total slightly above budget at $750 to round up.
+
+**Resolution:** The TSC agreed to award $250 to each of the three contributors.
+
+**Action Items:**
+- @nzakas will notify the contributors.
+
+### Scheduled Release for June 12th, 2026
+
+**Discussion Points:**
+- @mdjermanovic will do the release, and it will include just `eslint` this time.
+- After the `eslint` release, @mdjermanovic will release `@eslint/mcp` with an updated `eslint` dependency.
+
+**Action Items:**
+- @mdjermanovic will:
+  - Release `eslint`
+  - Release `@eslint/mcp` with an updated `eslint` dependency

--- a/notes/2026/2026-06-11.md
+++ b/notes/2026/2026-06-11.md
@@ -86,9 +86,9 @@
 
 **TSC Summary:** @nzakas noted that donations are currently down to $7,699.08/month, the lowest level in a long time. He has reached out to some lapsed sponsors and isn't sure what else can be done, but wanted to flag this in case levels continue to drop.
 
-### Contributor Pool for June 2026
+### Contributor Pool for May 2026
 
-**TSC Summary:** The team reviewed the [June contributor pool](https://github.com/eslint/tsc-meetings/blob/main/notes/2026/2026-06-01-contributor-pool.md), with a budget of $741.50 for the month.
+**TSC Summary:** The team reviewed the [May contributor pool](https://github.com/eslint/tsc-meetings/blob/main/notes/2026/2026-06-01-contributor-pool.md), with a budget of $741.50 for the month.
 
 **Discussion Points:**
 - @mdjermanovic proposed $250 for each of the three contributors, as the effort looked about the same, putting the total slightly above budget at $750 to round up.

--- a/notes/2026/2026-08-20.md
+++ b/notes/2026/2026-08-20.md
@@ -1,0 +1,73 @@
+# 2026-08-20 ESLint TSC Meeting Notes
+
+## Transcript
+
+[`2026-08-20-transcript.md`](2026-08-20-transcript.md)
+
+## Attending
+
+- Nicholas C. Zakas (@nzakas) - TSC
+- Milos Djermanovic (@mdjermanovic) - TSC
+- Francesco Trotta (@fasttime) - TSC
+
+@nzakas moderated.
+
+## Topics
+
+### Follow-up from Previous Meeting
+
+**TSC Summary:** No follow-up items to review from the previous meeting.
+
+### Statuses
+
+* **@nzakas:** Back to full strength. Has been working on a new JS/TS parser (via Claude) and otherwise doing issue and PR triage.
+* **@mdjermanovic:** Was only reviewing PRs and triaging issues the past two weeks.
+* **@fasttime:** Was also busy with triaging and reviews most of the time.
+
+### Availability Next Two Weeks
+
+* **@nzakas:** Roughly 5 hours per week.
+* **@mdjermanovic:** Expects to be available 2 hours per day the next two weeks.
+* **@fasttime:** Expects to remain available about 7 hours per week the next weeks.
+
+**RFC Duty:**
+- This week: @nzakas
+- August 24: @fasttime
+- August 31: @mdjermanovic
+
+### [Deprecate npm packages for end-of-life ESLint v9.x](https://github.com/eslint/eslint/issues/21209)
+
+**TSC Summary:** This issue proposes deprecating npm packages of `eslint` v9.x, which are end-of-life as of today. The TSC also considered whether to introduce a policy of deprecating npm packages once a major release line reaches end-of-life, noted in the [Manage Releases](https://github.com/eslint/eslint/blob/main/docs/src/maintain/manage-releases.md) documentation.
+
+**Discussion Points:**
+- @mdjermanovic noted the TSC already did the same when v0.x-v8.x reached end-of-life, so this makes sense.
+- @fasttime confirmed old packages were last deprecated when v9 was released, but there was no standing agenda item for doing this on subsequent major releases.
+- The group agreed this should be documented as a formal policy going forward.
+- @fasttime volunteered to deprecate the v9.x packages; @nzakas volunteered to announce the deprecation via social media.
+- @mdjermanovic suggested doing this now rather than waiting for tomorrow's release, since it isn't related to the release itself.
+
+**Resolution:** The TSC agreed to deprecate the `eslint` v9.x npm packages now (not tied to tomorrow's release), document a policy of deprecating npm packages once a major release line reaches end-of-life in the Manage Releases documentation, and announce the deprecation via social media.
+
+**Action Items:**
+- @fasttime will deprecate the `eslint` v9.x npm packages and update the Manage Releases documentation with the new policy.
+- @nzakas will announce the deprecation via social media.
+
+### AI-Assisted "Big Swing" Projects
+
+**TSC Summary:** @nzakas raised that having a free Claude Max account opens up the possibility of taking on ambitious projects that wouldn't otherwise have had time, and sought alignment on pursuing: a new JS/TypeScript parser, new evaluation tools (new versions of `eslint-scope` and code path analysis), a Bash plugin, a Docker plugin, and async core.
+
+**Discussion Points:**
+- @mdjermanovic asked whether async core was planned as part of the complete rewrite of ESLint; @nzakas confirmed it is part of that rewrite work rather than separate from it, referencing a rough plan he's had for a while ([2-year-old TypeScript support discussion](https://github.com/eslint/eslint/discussions/18830), [4-year-old async discussion](https://github.com/eslint/eslint/discussions/16557)).
+- @fasttime asked whether the async core work would include async parsers and async rules; @nzakas confirmed, and also confirmed that code path analysis revamp is part of the same parser/scope package (@fasttime had asked whether async core would also revamp code path analysis, or if that should be a separate topic).
+- @nzakas reported he already has a half-decent JS/TypeScript parser (around 60% faster than Espree) and an equivalent of `eslint-scope` supporting both JavaScript and TypeScript, with an RFC anticipated some time next week.
+- @fasttime raised an open PR to generate rule types from rule schemas ([eslint/eslint#20061](https://github.com/eslint/eslint/pull/20061)) as another area that could benefit from AI assistance, noting it's currently stalled on review; he plans to review it soon since results could be compared against existing output to keep risk low.
+
+**Resolution:** The TSC agreed to move forward with the new JS/TypeScript parser, new evaluation tools (parser/scope/code path analysis as one package), Bash plugin, Docker plugin, and async core as part of the ESLint rewrite effort.
+
+### Scheduled Release for August 21st, 2026
+
+**Discussion Points:**
+- @mdjermanovic will do the release, including just the `eslint` package.
+
+**Action Items:**
+- @mdjermanovic will release `eslint`.


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### AI acknowledgment

- [ ] I did _not_ use AI to generate this PR.
- [x] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request?

Add meeting notes where they were missing.

#### What changes did you make? (Give an overview)

Added meeting notes for 2026-06-11 and 2026-08-20.

Added an agent skill for generating meeting notes. This will make it easy for us to automate this in the future.

#### Related Issues

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified that summary-only requests do not modify repository files, while note-generation requests preserve transcripts and create meeting notes.
  * Added requirements for moderator attribution, GitHub issue and pull request headings, Markdown fences, and heading validation.
  * Added contributor-pool reporting guidance, including covered-month naming and report date-range verification.
  * Added ESLint TSC meeting notes for June 11 and August 20, 2026, covering attendance, availability, RFC assignments, project decisions, release plans, and action items.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->